### PR TITLE
switch to Java 11 (from 1.8)

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'temurin'
           cache: 'maven'
       - run: mvn --batch-mode --update-snapshots verify

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # build environment
-FROM eclipse-temurin:8-alpine as build
+FROM eclipse-temurin:11-alpine as build
 WORKDIR /app
 COPY . ./
 RUN ./mvnw --batch-mode verify
 
 # server environment
-FROM eclipse-temurin:8-alpine
+FROM eclipse-temurin:11-alpine
 COPY --from=build /app/target/cookbook-1.0.0-SNAPSHOT.jar .
 ENV PORT=80 \
     HOST=0.0.0.0

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Do you use food? Do you use software? Brenna's Food Software is for you!
 
 ## Build and Test
 
-You'll need Java 8 to build. A more specific version may be stipulated at some
-point (though likely not before upgrading past Java 9/Jigsaw):
+You'll need Java 11 to build. A more specific version may be stipulated at some
+point:
 
     ./mvnw package
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <description>Personal CookBook and meal planning software</description>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <org.liquibase.version>3.6.3</org.liquibase.version>
         <antlr4.visitor>true</antlr4.visitor>
         <antlr4.listener>true</antlr4.listener>

--- a/src/main/java/com/brennaswitzer/cookbook/domain/CompoundQuantity.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/CompoundQuantity.java
@@ -3,7 +3,6 @@ package com.brennaswitzer.cookbook.domain;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.val;
-import lombok.var;
 import org.hibernate.annotations.SortComparator;
 
 import javax.persistence.*;


### PR DESCRIPTION
No more Beanstalk. Containers for test and deploy. CI for branches. Sweeping changes with confidence... GO GO GO!