### PR TITLE
API bits for favorites subsystem

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/domain/Favorite.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/Favorite.java
@@ -1,0 +1,25 @@
+package com.brennaswitzer.cookbook.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+
+@Entity
+public class Favorite extends BaseEntity implements Owned {
+
+    @Getter
+    @Setter
+    @ManyToOne
+    private User owner;
+
+    @Getter
+    @Setter
+    private Long objectId;
+
+    @Getter
+    @Setter
+    private String objectType;
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/domain/FavoriteType.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/FavoriteType.java
@@ -1,0 +1,23 @@
+package com.brennaswitzer.cookbook.domain;
+
+import lombok.Getter;
+
+public enum FavoriteType {
+    RECIPE(Recipe.class);
+
+    @Getter
+    private final String key;
+
+    FavoriteType(Class<? extends BaseEntity> clazz) {
+        this(clazz.getSimpleName());
+    }
+
+    FavoriteType(String key) {
+        this.key = key;
+    }
+
+    public boolean matches(String key) {
+        return this.key.equals(key);
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/FavoriteMutation.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/FavoriteMutation.java
@@ -1,0 +1,25 @@
+package com.brennaswitzer.cookbook.graphql;
+
+import com.brennaswitzer.cookbook.domain.Favorite;
+import com.brennaswitzer.cookbook.services.favorites.UpdateFavorites;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@SuppressWarnings("unused")
+@Component
+public class FavoriteMutation {
+
+    @Autowired
+    private UpdateFavorites updateFavorites;
+
+    Favorite markFavorite(String objectType, Long objectId) {
+        return updateFavorites.ensureFavorite(objectType,
+                                              objectId);
+    }
+
+    boolean removeFavorite(String objectType, Long objectId) {
+        return updateFavorites.ensureNotFavorite(objectType,
+                                                 objectId);
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/FavoriteQuery.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/FavoriteQuery.java
@@ -1,0 +1,29 @@
+package com.brennaswitzer.cookbook.graphql;
+
+import com.brennaswitzer.cookbook.domain.Favorite;
+import com.brennaswitzer.cookbook.services.favorites.FetchFavorites;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@SuppressWarnings("unused")
+@Component
+public class FavoriteQuery {
+
+    @Autowired
+    private FetchFavorites fetchFavorites;
+
+    public List<Favorite> all() {
+        return fetchFavorites.all();
+    }
+
+    public List<Favorite> byType(String objectType) {
+        return fetchFavorites.byType(objectType);
+    }
+
+    public Favorite byObject(String objectType, Long objectId) {
+        return fetchFavorites.byObject(objectType, objectId);
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/Mutation.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/Mutation.java
@@ -10,4 +10,7 @@ public class Mutation implements GraphQLMutationResolver {
     @Autowired
     public TimerMutation timer;
 
+    @Autowired
+    public FavoriteMutation favorite;
+
 }

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/Query.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/Query.java
@@ -1,6 +1,10 @@
 package com.brennaswitzer.cookbook.graphql;
 
-import com.brennaswitzer.cookbook.domain.*;
+import com.brennaswitzer.cookbook.domain.AccessControlled;
+import com.brennaswitzer.cookbook.domain.AccessLevel;
+import com.brennaswitzer.cookbook.domain.Task;
+import com.brennaswitzer.cookbook.domain.TaskList;
+import com.brennaswitzer.cookbook.domain.User;
 import com.brennaswitzer.cookbook.repositories.BaseEntityRepository;
 import com.brennaswitzer.cookbook.services.TaskService;
 import com.brennaswitzer.cookbook.util.UserPrincipalAccess;
@@ -28,6 +32,9 @@ public class Query implements GraphQLQueryResolver {
 
     @Autowired
     public TimerQuery timer;
+
+    @Autowired
+    public FavoriteQuery favorite;
 
     Object getNode(Long id) {
         return repositories.stream()

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/FavoriteRepository.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/FavoriteRepository.java
@@ -1,0 +1,26 @@
+package com.brennaswitzer.cookbook.repositories;
+
+import com.brennaswitzer.cookbook.domain.Favorite;
+import com.brennaswitzer.cookbook.domain.User;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface FavoriteRepository extends BaseEntityRepository<Favorite> {
+
+    List<Favorite> findByOwner(User owner);
+
+    List<Favorite> findByOwnerAndObjectType(User owner,
+                                            String objectType);
+
+    Optional<Favorite> findByOwnerAndObjectTypeAndObjectId(User owner,
+                                                           String objectType,
+                                                           Long objectId);
+
+    int deleteByOwnerAndObjectTypeAndObjectId(User owner,
+                                              String objectType,
+                                              Long objectId);
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/RecipeSearchRepository.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/RecipeSearchRepository.java
@@ -9,15 +9,15 @@ import java.util.Collection;
 
 public interface RecipeSearchRepository {
 
-    Slice<Recipe> searchRecipes(
-            String term,
-            Pageable pageable
+    Slice<Recipe> searchRecipes(User user,
+                                String term,
+                                Pageable pageable
     );
 
-    Slice<Recipe> searchRecipesByOwner(
-            Collection<User> owners,
-            String term,
-            Pageable pageable
+    Slice<Recipe> searchRecipesByOwner(User user,
+                                       Collection<User> owners,
+                                       String term,
+                                       Pageable pageable
     );
 
 }

--- a/src/main/java/com/brennaswitzer/cookbook/resolvers/FavoriteResolver.java
+++ b/src/main/java/com/brennaswitzer/cookbook/resolvers/FavoriteResolver.java
@@ -1,0 +1,33 @@
+package com.brennaswitzer.cookbook.resolvers;
+
+import com.brennaswitzer.cookbook.domain.Favorite;
+import com.brennaswitzer.cookbook.domain.FavoriteType;
+import com.brennaswitzer.cookbook.domain.Recipe;
+import com.brennaswitzer.cookbook.services.RecipeService;
+import graphql.kickstart.tools.GraphQLResolver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FavoriteResolver implements GraphQLResolver<Favorite> {
+
+    @Autowired
+    private RecipeService recipeService;
+
+    public String getName(Favorite favorite) {
+        if (FavoriteType.RECIPE.matches(favorite.getObjectType())) {
+            return recipeService.findRecipeById(favorite.getObjectId())
+                    .map(Recipe::getName)
+                    .orElseGet(() -> getDefaultName(favorite));
+        } else {
+            return getDefaultName(favorite);
+        }
+    }
+
+    private static String getDefaultName(Favorite favorite) {
+        return String.format("%s#%d",
+                             favorite.getObjectType(),
+                             favorite.getObjectId());
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/services/RecipeService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/RecipeService.java
@@ -1,6 +1,7 @@
 package com.brennaswitzer.cookbook.services;
 
 import com.brennaswitzer.cookbook.domain.Recipe;
+import com.brennaswitzer.cookbook.domain.User;
 import com.brennaswitzer.cookbook.repositories.RecipeRepository;
 import com.brennaswitzer.cookbook.util.UserPrincipalAccess;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,11 +63,13 @@ public class RecipeService {
     }
 
     public Slice<Recipe> searchRecipes(String scope, String filter, Pageable pageable) {
+        User user = principalAccess.getUser();
         if ("everyone".equals(scope)) {
-            return recipeRepository.searchRecipes(filter, pageable);
+            return recipeRepository.searchRecipes(user, filter, pageable);
         } else {
             return recipeRepository.searchRecipesByOwner(
-                    Collections.singletonList(principalAccess.getUser()),
+                    user,
+                    Collections.singletonList(user),
                     filter,
                     pageable);
         }

--- a/src/main/java/com/brennaswitzer/cookbook/services/favorites/FetchFavorites.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/favorites/FetchFavorites.java
@@ -1,0 +1,38 @@
+package com.brennaswitzer.cookbook.services.favorites;
+
+import com.brennaswitzer.cookbook.domain.Favorite;
+import com.brennaswitzer.cookbook.repositories.FavoriteRepository;
+import com.brennaswitzer.cookbook.util.UserPrincipalAccess;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class FetchFavorites {
+
+    @Autowired
+    private FavoriteRepository repo;
+
+    @Autowired
+    private UserPrincipalAccess principalAccess;
+
+    public List<Favorite> all() {
+        return repo.findByOwner(principalAccess.getUser());
+    }
+
+    public List<Favorite> byType(String objectType) {
+        return repo.findByOwnerAndObjectType(principalAccess.getUser(),
+                                             objectType);
+    }
+
+    public Favorite byObject(String objectType, Long objectId) {
+        return repo.findByOwnerAndObjectTypeAndObjectId(principalAccess.getUser(),
+                                                        objectType,
+                                                        objectId)
+                .orElse(null);
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/services/favorites/UpdateFavorites.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/favorites/UpdateFavorites.java
@@ -1,0 +1,41 @@
+package com.brennaswitzer.cookbook.services.favorites;
+
+import com.brennaswitzer.cookbook.domain.Favorite;
+import com.brennaswitzer.cookbook.domain.User;
+import com.brennaswitzer.cookbook.repositories.FavoriteRepository;
+import com.brennaswitzer.cookbook.util.UserPrincipalAccess;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class UpdateFavorites {
+
+    @Autowired
+    private FavoriteRepository repo;
+
+    @Autowired
+    private UserPrincipalAccess principalAccess;
+
+    public Favorite ensureFavorite(String objectType, Long objectId) {
+        User user = principalAccess.getUser();
+        return repo.findByOwnerAndObjectTypeAndObjectId(user,
+                                                        objectType,
+                                                        objectId)
+                .orElseGet(() -> {
+                    Favorite fav = new Favorite();
+                    fav.setOwner(user);
+                    fav.setObjectType(objectType);
+                    fav.setObjectId(objectId);
+                    return repo.save(fav);
+                });
+    }
+
+    public boolean ensureNotFavorite(String objectType, Long objectId) {
+        return 0 < repo.deleteByOwnerAndObjectTypeAndObjectId(principalAccess.getUser(),
+                                                              objectType,
+                                                              objectId);
+    }
+
+}

--- a/src/main/resources/db/changelog/foodinger-2023.sql
+++ b/src/main/resources/db/changelog/foodinger-2023.sql
@@ -82,3 +82,21 @@ SELECT id
 FROM ingredient
 WHERE dtype = 'Recipe'
 ON CONFLICT DO NOTHING;
+
+--changeset barneyb:favorites
+CREATE TABLE favorite
+(
+    id          BIGINT      NOT NULL DEFAULT NEXTVAL('id_seq'),
+    _eqkey      BIGINT      NOT NULL,
+    created_at  timestamptz NOT NULL DEFAULT NOW(),
+    updated_at  timestamptz NOT NULL DEFAULT NOW(),
+    owner_id    BIGINT      NOT NULL,
+    object_id   BIGINT      NOT NULL,
+    object_type VARCHAR     NOT NULL,
+    CONSTRAINT pk_favorite PRIMARY KEY (id),
+    CONSTRAINT fk_favorite_user FOREIGN KEY (owner_id)
+        REFERENCES users (id) ON DELETE CASCADE,
+    -- object_id will partition most quickly
+    -- also supports per-object fav count queries
+    CONSTRAINT uk_favorite UNIQUE (object_id, object_type, owner_id)
+);

--- a/src/main/resources/graphqls/favorites.graphqls
+++ b/src/main/resources/graphqls/favorites.graphqls
@@ -1,0 +1,41 @@
+extend type Query {
+    favorite: FavoriteQuery
+}
+
+type FavoriteQuery {
+    """Retrieve the current user's favorites.
+    """
+    all: [Favorite!]!
+    """Retrieve the current user's for the specified object type.
+    """
+    byType(objectType: String!): [Favorite!]!
+    """Retrieve the current user's favorite of the specified object, if exists.
+    """
+    byObject(objectType: String!, objectId: ID!): Favorite
+}
+
+extend type Mutation {
+    favorite: FavoriteMutation
+}
+
+type FavoriteMutation {
+    """Add the specified object to the current user's favorites, if not already
+    present, and returns the favorite.
+    """
+    markFavorite(objectType: String!, objectId: ID!): Favorite!
+    """Remove the specified object from the current user's favorites, and return
+    whether any action was required to ensure this.
+    """
+    removeFavorite(objectType: String!, objectId: ID!): Boolean!
+}
+
+type Favorite implements Node {
+    id: ID!
+    owner: User!
+    """The type of object that is a favorite.
+    """
+    objectType: String!
+    """The ID of the object that is a favorite.
+    """
+    objectId: ID!
+}

--- a/src/main/resources/graphqls/favorites.graphqls
+++ b/src/main/resources/graphqls/favorites.graphqls
@@ -38,4 +38,7 @@ type Favorite implements Node {
     """The ID of the object that is a favorite.
     """
     objectId: ID!
+    """The name/title of the object that is a favorite.
+    """
+    name: String!
 }

--- a/src/test/java/com/brennaswitzer/cookbook/repositories/RecipeSearchRepositoryImplTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/repositories/RecipeSearchRepositoryImplTest.java
@@ -20,12 +20,12 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -90,10 +90,10 @@ public class RecipeSearchRepositoryImplTest {
                 .createNativeQuery(sqlCaptor.capture(), eq(Recipe.class));
         verify(query)
                 .setParameter(eq("userId"), eq(2L));
-        String sql = sqlCaptor.getValue();
-        assertTrue(sql.contains(RecipeSearchRepositoryImpl.SELECT_ALL));
-        assertFalse(sql.contains(RecipeSearchRepositoryImpl.OWNER_CLAUSE));
-        assertTrue(sql.contains(RecipeSearchRepositoryImpl.ORDER_BY_ALL));
+        verify(query, never())
+                .setParameter(eq("query"), any());
+        verify(query, never())
+                .setParameter(eq("ownerIds"), any());
     }
 
     @Test
@@ -112,11 +112,9 @@ public class RecipeSearchRepositoryImplTest {
                 .setParameter(eq("userId"), eq(2L));
         verify(query)
                 .setParameter(eq("query"), queryCaptor.capture());
-        String sql = sqlCaptor.getValue();
-        assertTrue(sql.contains(RecipeSearchRepositoryImpl.SELECT_FULLTEXT));
-        assertFalse(sql.contains(RecipeSearchRepositoryImpl.OWNER_CLAUSE));
-        assertTrue(sql.contains(RecipeSearchRepositoryImpl.ORDER_BY_FULLTEXT));
         assertEquals(tsquery, queryCaptor.getValue());
+        verify(query, never())
+                .setParameter(eq("ownerIds"), any());
     }
 
     @Test
@@ -127,12 +125,10 @@ public class RecipeSearchRepositoryImplTest {
                 .createNativeQuery(sqlCaptor.capture(), eq(Recipe.class));
         verify(query)
                 .setParameter(eq("userId"), eq(2L));
+        verify(query, never())
+                .setParameter(eq("query"), any());
         verify(query)
                 .setParameter(eq("ownerIds"), eq(Set.of(2L)));
-        String sql = sqlCaptor.getValue();
-        assertTrue(sql.contains(RecipeSearchRepositoryImpl.SELECT_ALL));
-        assertTrue(sql.contains(RecipeSearchRepositoryImpl.OWNER_CLAUSE));
-        assertTrue(sql.contains(RecipeSearchRepositoryImpl.ORDER_BY_ALL));
     }
 
     @Test
@@ -147,10 +143,6 @@ public class RecipeSearchRepositoryImplTest {
                 .setParameter(eq("ownerIds"), eq(Set.of(2L)));
         verify(query)
                 .setParameter(eq("query"), queryCaptor.capture());
-        String sql = sqlCaptor.getValue();
-        assertTrue(sql.contains(RecipeSearchRepositoryImpl.SELECT_FULLTEXT));
-        assertTrue(sql.contains(RecipeSearchRepositoryImpl.OWNER_CLAUSE));
-        assertTrue(sql.contains(RecipeSearchRepositoryImpl.ORDER_BY_FULLTEXT));
     }
 
 }


### PR DESCRIPTION
Create a new `Favorite` type and expose it via the GraphQL schema. 

The storage is generic, so it can be reused beyond just the library. Right
now it's only hooked up to Recipes.