### PR TITLE
Library offset paging

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/payload/Page.java
+++ b/src/main/java/com/brennaswitzer/cookbook/payload/Page.java
@@ -2,23 +2,12 @@ package com.brennaswitzer.cookbook.payload;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
 @Data
 @AllArgsConstructor
 public class Page<E> {
-
-    public static <E> Page<E> from(Slice<E> slice) {
-        return new Page<>(
-                slice.getNumber(),
-                slice.getSize(),
-                slice.isFirst(),
-                slice.isLast(),
-                slice.getContent()
-        );
-    }
 
     private int page;
     private int pageSize;

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/RecipeSearchRepository.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/RecipeSearchRepository.java
@@ -1,23 +1,10 @@
 package com.brennaswitzer.cookbook.repositories;
 
 import com.brennaswitzer.cookbook.domain.Recipe;
-import com.brennaswitzer.cookbook.domain.User;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-
-import java.util.Collection;
+import com.brennaswitzer.cookbook.repositories.impl.LibrarySearchRequest;
 
 public interface RecipeSearchRepository {
 
-    Slice<Recipe> searchRecipes(User user,
-                                String term,
-                                Pageable pageable
-    );
-
-    Slice<Recipe> searchRecipesByOwner(User user,
-                                       Collection<User> owners,
-                                       String term,
-                                       Pageable pageable
-    );
+    SearchResponse<Recipe> searchRecipes(LibrarySearchRequest request);
 
 }

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/SearchRequest.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/SearchRequest.java
@@ -1,0 +1,22 @@
+package com.brennaswitzer.cookbook.repositories;
+
+import org.springframework.data.domain.Sort;
+
+public interface SearchRequest {
+
+    int getOffset();
+
+    int getLimit();
+
+    Sort getSort();
+
+    default boolean isOffset() {
+        return getOffset() > 0;
+    }
+
+    @SuppressWarnings("unused")
+    default boolean isSorted() {
+        return getSort().isSorted();
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/SearchResponse.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/SearchResponse.java
@@ -1,0 +1,63 @@
+package com.brennaswitzer.cookbook.repositories;
+
+import com.brennaswitzer.cookbook.repositories.impl.SearchResponseImpl;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+import java.util.function.Function;
+
+import static java.util.stream.Collectors.toList;
+
+public interface SearchResponse<R> {
+
+    List<R> getContent();
+
+    default int getSize() {
+        return getContent().size();
+    }
+
+    SearchRequest getRequest();
+
+    default int getOffset() {
+        return getRequest().getOffset();
+    }
+
+    @SuppressWarnings("unused")
+    default int getLimit() {
+        return getRequest().getLimit();
+    }
+
+    @SuppressWarnings("unused")
+    default Sort getSort() {
+        return getRequest().getSort();
+    }
+
+    boolean isLast();
+
+    default boolean isFirst() {
+        return getOffset() == 0;
+    }
+
+    default <S> SearchResponse<S> map(Function<? super R, ? extends S> converter) {
+        return SearchResponseImpl.<S>builder()
+                .content(getContent().stream()
+                                 .map(converter)
+                                 .collect(toList()))
+                .request(getRequest())
+                .last(isLast())
+                .build();
+    }
+
+    static <R> SearchResponse<R> of(SearchRequest request,
+                                    List<R> contentPlusOne) {
+        boolean hasNext = contentPlusOne.size() > request.getLimit();
+        return SearchResponseImpl.<R>builder()
+                .content(hasNext
+                                 ? contentPlusOne.subList(0, request.getLimit())
+                                 : contentPlusOne)
+                .request(request)
+                .last(!hasNext)
+                .build();
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/impl/LibrarySearchRequest.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/impl/LibrarySearchRequest.java
@@ -1,0 +1,28 @@
+package com.brennaswitzer.cookbook.repositories.impl;
+
+import com.brennaswitzer.cookbook.domain.User;
+import com.brennaswitzer.cookbook.repositories.SearchRequest;
+import lombok.Builder;
+import lombok.Value;
+import org.springframework.data.domain.Sort;
+
+@Value
+@Builder
+public class LibrarySearchRequest implements SearchRequest {
+
+    LibrarySearchScope scope;
+    User user;
+    String filter;
+    int offset;
+    int limit;
+    Sort sort;
+
+    public boolean isFiltered() {
+        return filter != null && !filter.isBlank();
+    }
+
+    public boolean isOwnerConstrained() {
+        return !LibrarySearchScope.EVERYONE.equals(scope);
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/impl/LibrarySearchScope.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/impl/LibrarySearchScope.java
@@ -1,0 +1,6 @@
+package com.brennaswitzer.cookbook.repositories.impl;
+
+public enum LibrarySearchScope {
+    MINE,
+    EVERYONE
+}

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/impl/SearchResponseImpl.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/impl/SearchResponseImpl.java
@@ -1,0 +1,18 @@
+package com.brennaswitzer.cookbook.repositories.impl;
+
+import com.brennaswitzer.cookbook.repositories.SearchRequest;
+import com.brennaswitzer.cookbook.repositories.SearchResponse;
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.List;
+
+@Value
+@Builder
+public class SearchResponseImpl<R> implements SearchResponse<R> {
+
+    List<R> content;
+    SearchRequest request;
+    boolean last;
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/services/RecipeService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/RecipeService.java
@@ -1,16 +1,15 @@
 package com.brennaswitzer.cookbook.services;
 
 import com.brennaswitzer.cookbook.domain.Recipe;
-import com.brennaswitzer.cookbook.domain.User;
 import com.brennaswitzer.cookbook.repositories.RecipeRepository;
+import com.brennaswitzer.cookbook.repositories.SearchResponse;
+import com.brennaswitzer.cookbook.repositories.impl.LibrarySearchRequest;
+import com.brennaswitzer.cookbook.repositories.impl.LibrarySearchScope;
 import com.brennaswitzer.cookbook.util.UserPrincipalAccess;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
 import java.util.Optional;
 
 @Service
@@ -29,17 +28,13 @@ public class RecipeService {
     @Autowired
     private UserPrincipalAccess principalAccess;
 
-    @Autowired
-    @Deprecated
-    private ItemService itemService;
-
     public Recipe createNewRecipe(Recipe recipe) {
         recipe.setOwner(principalAccess.getUser());
         return recipeRepository.save(recipe);
     }
 
     public Recipe updateRecipe(Recipe recipe) {
-        Recipe existing = recipeRepository.getOne(recipe.getId());
+        Recipe existing = recipeRepository.getReferenceById(recipe.getId());
         if (!existing.getOwner().equals(principalAccess.getUser())) {
             throw new RuntimeException("You can't update other people's recipes.");
         }
@@ -51,7 +46,7 @@ public class RecipeService {
     }
 
     public void deleteRecipeById(Long id) {
-        Recipe r = recipeRepository.getOne(id);
+        Recipe r = recipeRepository.getReferenceById(id);
         planService.severLibraryLinks(r);
         recipeRepository.delete(r);
     }
@@ -59,20 +54,31 @@ public class RecipeService {
     @SuppressWarnings("OptionalGetWithoutIsPresent")
     public void sendToPlan(Long recipeId, Long planId) {
         planService.addRecipe(planId,
-                recipeRepository.findById(recipeId).get());
+                              recipeRepository.findById(recipeId).get());
     }
 
-    public Slice<Recipe> searchRecipes(String scope, String filter, Pageable pageable) {
-        User user = principalAccess.getUser();
-        if ("everyone".equals(scope)) {
-            return recipeRepository.searchRecipes(user, filter, pageable);
-        } else {
-            return recipeRepository.searchRecipesByOwner(
-                    user,
-                    Collections.singletonList(user),
-                    filter,
-                    pageable);
-        }
+    public SearchResponse<Recipe> searchRecipes(String scope,
+                                                String filter,
+                                                int offset,
+                                                int limit) {
+        return searchRecipes(LibrarySearchScope.valueOf(scope.toUpperCase()),
+                             filter,
+                             offset,
+                             limit);
+    }
+
+    public SearchResponse<Recipe> searchRecipes(LibrarySearchScope scope,
+                                                String filter,
+                                                int offset,
+                                                int limit) {
+        return recipeRepository.searchRecipes(
+                LibrarySearchRequest.builder()
+                        .user(principalAccess.getUser())
+                        .scope(scope)
+                        .filter(filter)
+                        .offset(offset)
+                        .limit(limit)
+                        .build());
     }
 
 }

--- a/src/main/java/com/brennaswitzer/cookbook/web/RecipeController.java
+++ b/src/main/java/com/brennaswitzer/cookbook/web/RecipeController.java
@@ -7,6 +7,7 @@ import com.brennaswitzer.cookbook.domain.S3File;
 import com.brennaswitzer.cookbook.mapper.IngredientMapper;
 import com.brennaswitzer.cookbook.payload.IngredientInfo;
 import com.brennaswitzer.cookbook.payload.Page;
+import com.brennaswitzer.cookbook.repositories.SearchResponse;
 import com.brennaswitzer.cookbook.services.ItemService;
 import com.brennaswitzer.cookbook.services.LabelService;
 import com.brennaswitzer.cookbook.services.RecipeService;
@@ -17,8 +18,6 @@ import com.brennaswitzer.cookbook.util.ShareHelper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -82,8 +81,18 @@ public class RecipeController {
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "pageSize", defaultValue = "99999") int pageSize
     ) {
-        Slice<Recipe> rs = recipeService.searchRecipes(scope, filter, PageRequest.of(page, pageSize));
-        return Page.from(rs.map(ingredientMapper::recipeToInfo));
+        SearchResponse<IngredientInfo> response = recipeService.searchRecipes(
+                        scope,
+                        filter,
+                        page * pageSize,
+                        pageSize)
+                .map(ingredientMapper::recipeToInfo);
+        return new Page<>(
+                page,
+                pageSize,
+                response.isFirst(),
+                response.isLast(),
+                response.getContent());
     }
 
     @PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)


### PR DESCRIPTION
Library search has used Spring Data's Pageable/Slice abstractions, but they
only support paging through, not arbitrary slices of a result. So change to
use an offset/limit style way of constrainting results, which can support the
same paging behavior, as well as the cursor-based behavior that Relay wants.