### PR TITLE
accept a scaling factor when adding recipes to the plan

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/services/RecipeService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/RecipeService.java
@@ -51,10 +51,15 @@ public class RecipeService {
         recipeRepository.delete(r);
     }
 
-    @SuppressWarnings("OptionalGetWithoutIsPresent")
     public void sendToPlan(Long recipeId, Long planId) {
+        sendToPlan(recipeId, planId, 1d);
+    }
+
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    public void sendToPlan(Long recipeId, Long planId, Double scale) {
         planService.addRecipe(planId,
-                              recipeRepository.findById(recipeId).get());
+                              recipeRepository.findById(recipeId).get(),
+                              scale);
     }
 
     public SearchResponse<Recipe> searchRecipes(String scope,

--- a/src/main/java/com/brennaswitzer/cookbook/web/RecipeController.java
+++ b/src/main/java/com/brennaswitzer/cookbook/web/RecipeController.java
@@ -248,9 +248,9 @@ public class RecipeController {
     @DeleteMapping("/{id}/labels/{label}")
     @Transactional
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void removeLable(
-            @PathVariable Long id,
-            @PathVariable String label
+    public void removeLabel(
+        @PathVariable Long id,
+        @PathVariable String label
     ) {
         Recipe recipe = getRecipe(id);
         labelService.removeLabel(recipe, label);
@@ -259,10 +259,11 @@ public class RecipeController {
     @PostMapping("/{id}/_send_to_plan/{planId}")
     @ResponseBody
     public Object performRecipeAction(
-            @PathVariable("id") Long id,
-            @PathVariable("planId") Long planId
+        @PathVariable("id") Long id,
+        @PathVariable("planId") Long planId,
+        @RequestParam(name = "scale", defaultValue = "1") Double scale
     ) {
-        recipeService.sendToPlan(id, planId);
+        recipeService.sendToPlan(id, planId, scale);
         return true;
     }
 


### PR DESCRIPTION
By default, recipes are added at scale=1 (no scaling), but can be scaled by any factor. Only the recipe's ingredients will be scaled onto the plan, any subrecipes will be left unscaled.