### PR TITLE
only accept an implicit unit before the item

### DIFF
--- a/src/test/java/com/brennaswitzer/cookbook/services/ItemServiceTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/services/ItemServiceTest.java
@@ -88,6 +88,34 @@ public class ItemServiceTest {
         assertEquals(new RecognizedItem.Range(6, 11, RecognizedItem.Type.ITEM), ing);
     }
 
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    @Test
+    void multiNumberRecog() {
+        RecipeBox box = new RecipeBox();
+        box.persist(entityManager, principalAccess.getUser());
+        String raw = "12 flour, grated (~3 cups or 19 Tbsp)";
+
+        var recog = service.recognizeItem(raw, raw.length(), false);
+
+        var q = recog.getRanges()
+                .stream()
+                .filter(r -> r.getType() == RecognizedItem.Type.AMOUNT)
+                .findFirst()
+                .get();
+        assertEquals("12", raw.substring(q.getStart(), q.getEnd()));
+        var item = recog.getRanges()
+                .stream()
+                .filter(r -> r.getType() == RecognizedItem.Type.ITEM)
+                .findFirst()
+                .get();
+        assertEquals("flour", raw.substring(item.getStart(), item.getEnd()));
+        var optUnit = recog.getRanges()
+                .stream()
+                .filter(r -> r.getType() == RecognizedItem.Type.UNIT)
+                .findFirst();
+        assertFalse(optUnit.isPresent());
+    }
+
     @Test
     public void recognizeItemMultipleWords() {
         recognizeChickenThighs(raw ->

--- a/src/test/java/com/brennaswitzer/cookbook/util/RawUtilsTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/util/RawUtilsTest.java
@@ -27,6 +27,8 @@ public class RawUtilsTest {
         r.readLine(); // the header
         r.lines()
                 .filter(l -> !l.trim().isEmpty())
+                .filter(l -> !l.startsWith("#"))
+                .filter(l -> !l.startsWith("//"))
                 .map(l -> l.split("\\|"))
                 .map(this::inflateDissection)
                 .forEach(this::testDissection);


### PR DESCRIPTION
Addresses #20's mis-parse of 'each' ingredients w/ a subsequent unit reference.

<img width="181" alt="image" src="https://github.com/folded-ear/gobrennas-api/assets/82654/d983812f-5223-49c1-962e-b1cbd36cecc3">
