### PR TITLE
Planner graphql

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,11 @@
             <artifactId>ical4j</artifactId>
             <version>3.2.12</version>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/brennaswitzer/cookbook/config/GraphQLConfig.java
+++ b/src/main/java/com/brennaswitzer/cookbook/config/GraphQLConfig.java
@@ -36,6 +36,11 @@ public class GraphQLConfig {
     }
 
     @Bean
+    public GraphQLScalarType long_() {
+        return ExtendedScalars.GraphQLLong;
+    }
+
+    @Bean
     public GraphQLScalarType positiveInt() {
         return ExtendedScalars.PositiveInt;
     }
@@ -81,7 +86,8 @@ public class GraphQLConfig {
     ) {
         return new AsyncExecutionStrategy() {
             @Override
-            public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+            public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext,
+                                                              ExecutionStrategyParameters parameters) {
                 return txTmpl.execute(tx -> {
                     val result = super.execute(executionContext, parameters);
                     if (tx.isNewTransaction() && tx instanceof DefaultTransactionStatus) {

--- a/src/main/java/com/brennaswitzer/cookbook/domain/Acl.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/Acl.java
@@ -1,8 +1,16 @@
 package com.brennaswitzer.cookbook.domain;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Embeddable;
+import javax.persistence.ManyToOne;
+import javax.persistence.MapKeyJoinColumn;
 import javax.validation.constraints.NotNull;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 @SuppressWarnings("WeakerAccess")
 @Embeddable
@@ -48,6 +56,7 @@ public class Acl {
 
     public AccessLevel setGrant(User user, AccessLevel level) {
         if (user == null) throw new IllegalArgumentException("You can't grant access to the null user.");
+        if (level == null) throw new IllegalArgumentException("You can't grant a null access level.");
         if (user.equals(owner)) throw new UnsupportedOperationException();
         if (grants == null) grants = new HashMap<>();
         return grants.put(user, level);

--- a/src/main/java/com/brennaswitzer/cookbook/domain/Ingredient.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/Ingredient.java
@@ -28,7 +28,7 @@ import java.util.Set;
         @JsonSubTypes.Type(value = PantryItem.class, name = "PantryItem"),
         @JsonSubTypes.Type(value = Recipe.class, name = "Recipe")
 })
-public abstract class Ingredient extends BaseEntity implements Identified, Labeled {
+public abstract class Ingredient extends BaseEntity implements Identified, Named, Labeled {
 
     public static Comparator<Ingredient> BY_NAME = (a, b) -> {
         if (a == null) return b == null ? 0 : 1;

--- a/src/main/java/com/brennaswitzer/cookbook/domain/Named.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/Named.java
@@ -1,0 +1,7 @@
+package com.brennaswitzer.cookbook.domain;
+
+public interface Named {
+
+    String getName();
+    
+}

--- a/src/main/java/com/brennaswitzer/cookbook/domain/Plan.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/Plan.java
@@ -60,6 +60,10 @@ public class Plan extends PlanItem implements AccessControlled {
         return buckets;
     }
 
+    public int getBucketCount() {
+        return buckets == null ? 0 : buckets.size();
+    }
+
     public boolean hasBuckets() {
         return buckets != null && !buckets.isEmpty();
     }

--- a/src/main/java/com/brennaswitzer/cookbook/domain/PlanItem.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/PlanItem.java
@@ -41,7 +41,7 @@ import static javax.persistence.CascadeType.REFRESH;
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "_type")
 @DiscriminatorValue("item")
-public class PlanItem extends BaseEntity implements MutableItem {
+public class PlanItem extends BaseEntity implements Named, MutableItem {
 
     public static final Comparator<PlanItem> BY_ID = (a, b) -> {
         if (a == null) return b == null ? 0 : 1;

--- a/src/main/java/com/brennaswitzer/cookbook/domain/PlanItemStatus.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/PlanItemStatus.java
@@ -18,4 +18,7 @@ public enum PlanItemStatus implements Identified {
         return id;
     }
 
+    public boolean isForDelete() {
+        return COMPLETED.equals(this) || DELETED.equals(this);
+    }
 }

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/Mutation.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/Mutation.java
@@ -13,4 +13,7 @@ public class Mutation implements GraphQLMutationResolver {
     @Autowired
     public FavoriteMutation favorite;
 
+    @Autowired
+    public PlannerMutation planner;
+
 }

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Component
 public class PlannerMutation {
@@ -52,6 +53,10 @@ public class PlannerMutation {
 
     public PlanItem rename(Long id, String name) {
         return planService.renameItem(id, name);
+    }
+
+    public PlanItem reorderSubitems(Long id, List<Long> subitemIds) {
+        return planService.resetSubitems(id, subitemIds);
     }
 
     public PlanBucket updateBucket(Long planId, Long bucketId, String name, LocalDate date) {

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
@@ -1,5 +1,6 @@
 package com.brennaswitzer.cookbook.graphql;
 
+import com.brennaswitzer.cookbook.domain.Plan;
 import com.brennaswitzer.cookbook.domain.PlanBucket;
 import com.brennaswitzer.cookbook.domain.PlanItem;
 import com.brennaswitzer.cookbook.services.PlanService;
@@ -22,8 +23,16 @@ public class PlannerMutation {
         return planService.createBucket(planId, name, date);
     }
 
+    public Plan deleteBucket(Long planId, Long bucketId) {
+        return planService.deleteBucket(planId, bucketId).getPlan();
+    }
+
     public PlanItem rename(Long id, String name) {
         return planService.renameItem(id, name);
+    }
+
+    public PlanBucket updateBucket(Long planId, Long bucketId, String name, LocalDate date) {
+        return planService.updateBucket(planId, bucketId, name, date);
     }
 
 }

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
@@ -1,0 +1,29 @@
+package com.brennaswitzer.cookbook.graphql;
+
+import com.brennaswitzer.cookbook.domain.PlanBucket;
+import com.brennaswitzer.cookbook.domain.PlanItem;
+import com.brennaswitzer.cookbook.services.PlanService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+public class PlannerMutation {
+
+    @Autowired
+    private PlanService planService;
+
+    public PlanItem assignBucket(Long id, Long bucketId) {
+        return planService.assignItemBucket(id, bucketId);
+    }
+
+    public PlanBucket createBucket(Long planId, String name, LocalDate date) {
+        return planService.createBucket(planId, name, date);
+    }
+
+    public PlanItem rename(Long id, String name) {
+        return planService.renameItem(id, name);
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
@@ -36,8 +36,12 @@ public class PlannerMutation {
         return planService.deleteBucket(planId, bucketId).getPlan();
     }
 
+    public PlanItem deleteItem(Long id) {
+        return planService.deleteItemForParent(id);
+    }
+
     public boolean deletePlan(Long id) {
-        planService.deleteItem(id);
+        planService.deletePlan(id);
         return true;
     }
 

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
@@ -1,5 +1,6 @@
 package com.brennaswitzer.cookbook.graphql;
 
+import com.brennaswitzer.cookbook.domain.AccessLevel;
 import com.brennaswitzer.cookbook.domain.Plan;
 import com.brennaswitzer.cookbook.domain.PlanBucket;
 import com.brennaswitzer.cookbook.domain.PlanItem;
@@ -33,6 +34,14 @@ public class PlannerMutation {
 
     public PlanBucket updateBucket(Long planId, Long bucketId, String name, LocalDate date) {
         return planService.updateBucket(planId, bucketId, name, date);
+    }
+
+    public Plan setGrant(Long planId, Long userId, AccessLevel accessLevel) {
+        return planService.setGrantOnPlan(planId, userId, accessLevel);
+    }
+
+    public Plan deleteGrant(Long planId, Long userId) {
+        return planService.deleteGrantFromPlan(planId, userId);
     }
 
 }

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
@@ -51,12 +51,16 @@ public class PlannerMutation {
         return planService.duplicatePlan(name, sourcePlanId);
     }
 
+    public PlanItem mutateTree(List<Long> itemIds, Long parentId, Long afterId) {
+        return planService.mutateTree(itemIds, parentId, afterId);
+    }
+
     public PlanItem rename(Long id, String name) {
         return planService.renameItem(id, name);
     }
 
-    public PlanItem reorderSubitems(Long id, List<Long> subitemIds) {
-        return planService.resetSubitems(id, subitemIds);
+    public PlanItem reorderSubitems(Long parentId, List<Long> itemIds) {
+        return planService.resetSubitems(parentId, itemIds);
     }
 
     public PlanBucket updateBucket(Long planId, Long bucketId, String name, LocalDate date) {

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
@@ -4,6 +4,7 @@ import com.brennaswitzer.cookbook.domain.AccessLevel;
 import com.brennaswitzer.cookbook.domain.Plan;
 import com.brennaswitzer.cookbook.domain.PlanBucket;
 import com.brennaswitzer.cookbook.domain.PlanItem;
+import com.brennaswitzer.cookbook.domain.PlanItemStatus;
 import com.brennaswitzer.cookbook.services.PlanService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -59,6 +60,10 @@ public class PlannerMutation {
 
     public Plan setGrant(Long planId, Long userId, AccessLevel accessLevel) {
         return planService.setGrantOnPlan(planId, userId, accessLevel);
+    }
+
+    public PlanItem setStatus(Long id, PlanItemStatus status) {
+        return planService.setItemStatus(id, status);
     }
 
     public Plan deleteGrant(Long planId, Long userId) {

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
@@ -24,6 +24,10 @@ public class PlannerMutation {
         return planService.createBucket(planId, name, date);
     }
 
+    public PlanItem createItem(Long parentId, Long afterId, String name) {
+        return planService.createItem(parentId, afterId, name);
+    }
+
     public Plan deleteBucket(Long planId, Long bucketId) {
         return planService.deleteBucket(planId, bucketId).getPlan();
     }

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
@@ -28,8 +28,21 @@ public class PlannerMutation {
         return planService.createItem(parentId, afterId, name);
     }
 
+    public Plan createPlan(String name) {
+        return planService.createPlan(name);
+    }
+
     public Plan deleteBucket(Long planId, Long bucketId) {
         return planService.deleteBucket(planId, bucketId).getPlan();
+    }
+
+    public boolean deletePlan(Long id) {
+        planService.deleteItem(id);
+        return true;
+    }
+
+    public Plan duplicatePlan(String name, Long sourcePlanId) {
+        return planService.duplicatePlan(name, sourcePlanId);
     }
 
     public PlanItem rename(Long id, String name) {

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerQuery.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerQuery.java
@@ -6,6 +6,7 @@ import com.brennaswitzer.cookbook.services.PlanService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -26,6 +27,11 @@ public class PlannerQuery {
 
     PlanItem planItem(Long id) {
         return planService.getPlanItemById(id);
+    }
+
+    List<PlanItem> updatedSince(Long planId, Long cutoff) {
+        return planService.getTreeDeltasById(planId,
+                                             Instant.ofEpochMilli(cutoff));
     }
 
 }

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerQuery.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerQuery.java
@@ -1,0 +1,31 @@
+package com.brennaswitzer.cookbook.graphql;
+
+import com.brennaswitzer.cookbook.domain.Plan;
+import com.brennaswitzer.cookbook.domain.PlanItem;
+import com.brennaswitzer.cookbook.services.PlanService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+@Component
+public class PlannerQuery {
+
+    @Autowired
+    private PlanService planService;
+
+    List<Plan> plans() {
+        List<Plan> result = new ArrayList<>();
+        Iterable<Plan> plans = planService.getPlans();
+        Iterator<Plan> iterator = plans.iterator();
+        iterator.forEachRemaining(result::add);
+        return result;
+    }
+
+    PlanItem planItem(Long id) {
+        return planService.getPlanItemById(id);
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/Query.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/Query.java
@@ -2,18 +2,13 @@ package com.brennaswitzer.cookbook.graphql;
 
 import com.brennaswitzer.cookbook.domain.AccessControlled;
 import com.brennaswitzer.cookbook.domain.AccessLevel;
-import com.brennaswitzer.cookbook.domain.Plan;
-import com.brennaswitzer.cookbook.domain.PlanItem;
 import com.brennaswitzer.cookbook.domain.User;
 import com.brennaswitzer.cookbook.repositories.BaseEntityRepository;
-import com.brennaswitzer.cookbook.services.PlanService;
 import com.brennaswitzer.cookbook.util.UserPrincipalAccess;
 import graphql.kickstart.tools.GraphQLQueryResolver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,9 +18,6 @@ public class Query implements GraphQLQueryResolver {
 
     @Autowired
     private List<BaseEntityRepository<?>> repositories;
-
-    @Autowired
-    private PlanService planService;
 
     @Autowired
     private UserPrincipalAccess userPrincipalAccess;
@@ -42,6 +34,9 @@ public class Query implements GraphQLQueryResolver {
     @Autowired
     public LabelsQuery labels;
 
+    @Autowired
+    public PlannerQuery planner;
+
     Object getNode(Long id) {
         return repositories.stream()
                 .map(r -> r.findById(id))
@@ -53,18 +48,6 @@ public class Query implements GraphQLQueryResolver {
                                 AccessLevel.VIEW))
                 .findFirst()
                 .orElse(null);
-    }
-
-    List<Plan> getPlans() {
-        List<Plan> result = new ArrayList<>();
-        Iterable<Plan> plans = planService.getPlans();
-        Iterator<Plan> iterator = plans.iterator();
-        iterator.forEachRemaining(result::add);
-        return result;
-    }
-
-    PlanItem getPlanItem(Long id) {
-        return planService.getPlanItemById(id);
     }
 
     User getCurrentUser() {

--- a/src/main/java/com/brennaswitzer/cookbook/payload/ShareInfo.java
+++ b/src/main/java/com/brennaswitzer/cookbook/payload/ShareInfo.java
@@ -1,0 +1,16 @@
+package com.brennaswitzer.cookbook.payload;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ShareInfo {
+
+    Long id;
+    String slug;
+    String secret;
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/resolvers/PlanItemResolver.java
+++ b/src/main/java/com/brennaswitzer/cookbook/resolvers/PlanItemResolver.java
@@ -1,7 +1,6 @@
 package com.brennaswitzer.cookbook.resolvers;
 
 import com.brennaswitzer.cookbook.domain.PlanItem;
-import com.brennaswitzer.cookbook.domain.Quantity;
 import com.brennaswitzer.cookbook.services.PlanService;
 import graphql.kickstart.tools.GraphQLResolver;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,24 +10,14 @@ import java.util.List;
 
 import static com.brennaswitzer.cookbook.util.CollectionUtils.tail;
 
-@SuppressWarnings("unused") // component-scanned for graphql-java
 @Component
 public class PlanItemResolver implements GraphQLResolver<PlanItem> {
 
     @Autowired
     private PlanService planService;
 
-    public Double quantity(PlanItem item) {
-        return item.getQuantity().getQuantity();
-    }
-
-    public String units(PlanItem item) {
-        Quantity q = item.getQuantity();
-        if (q.hasUnits()) {
-            return q.getUnits().getName();
-        } else {
-            return null;
-        }
+    public PlanItem parent(PlanItem item) {
+        return item.getParent();
     }
 
     public List<PlanItem> children(PlanItem item) {
@@ -37,6 +26,10 @@ public class PlanItemResolver implements GraphQLResolver<PlanItem> {
 
     public List<PlanItem> components(PlanItem item) {
         return item.getOrderedComponentsView();
+    }
+
+    public int descendantCount(PlanItem item) {
+        return planService.getTreeById(item).size() - 1;
     }
 
     public List<PlanItem> descendants(PlanItem item) {

--- a/src/main/java/com/brennaswitzer/cookbook/resolvers/PlanResolver.java
+++ b/src/main/java/com/brennaswitzer/cookbook/resolvers/PlanResolver.java
@@ -2,7 +2,9 @@ package com.brennaswitzer.cookbook.resolvers;
 
 import com.brennaswitzer.cookbook.domain.Plan;
 import com.brennaswitzer.cookbook.domain.PlanItem;
+import com.brennaswitzer.cookbook.payload.ShareInfo;
 import com.brennaswitzer.cookbook.services.PlanService;
+import com.brennaswitzer.cookbook.util.ShareHelper;
 import graphql.kickstart.tools.GraphQLResolver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -16,6 +18,9 @@ public class PlanResolver implements GraphQLResolver<Plan> {
 
     @Autowired
     private PlanService planService;
+
+    @Autowired
+    private ShareHelper shareHelper;
 
     public List<AccessControlEntry> grants(Plan plan) {
         return AclHelpers.getGrants(plan);
@@ -31,6 +36,10 @@ public class PlanResolver implements GraphQLResolver<Plan> {
 
     public List<PlanItem> descendants(Plan plan) {
         return tail(planService.getTreeById(plan));
+    }
+
+    public ShareInfo share(Plan plan) {
+        return shareHelper.getInfo(Plan.class, plan);
     }
 
 }

--- a/src/main/java/com/brennaswitzer/cookbook/resolvers/PlanResolver.java
+++ b/src/main/java/com/brennaswitzer/cookbook/resolvers/PlanResolver.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import static com.brennaswitzer.cookbook.util.CollectionUtils.tail;
 
-@SuppressWarnings("unused") // component-scanned for graphql-java
 @Component
 public class PlanResolver implements GraphQLResolver<Plan> {
 
@@ -22,8 +21,12 @@ public class PlanResolver implements GraphQLResolver<Plan> {
         return AclHelpers.getGrants(plan);
     }
 
-    public List<PlanItem> children(PlanItem item) {
-        return item.getOrderedChildView();
+    public List<PlanItem> children(Plan plan) {
+        return plan.getOrderedChildView();
+    }
+
+    public int descendantCount(Plan item) {
+        return planService.getTreeById(item).size() - 1;
     }
 
     public List<PlanItem> descendants(Plan plan) {

--- a/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
@@ -137,7 +137,7 @@ public class PlanService {
                 .collect(Collectors.toList());
     }
 
-    public PlanMessage mutateTree(List<Long> ids, Long parentId, Long afterId) {
+    public PlanItem mutateTree(List<Long> ids, Long parentId, Long afterId) {
         PlanItem parent = getPlanItemById(parentId, AccessLevel.CHANGE);
         PlanItem after = afterId == null ? null : getPlanItemById(afterId, AccessLevel.VIEW);
         for (Long id : ids) {
@@ -145,6 +145,11 @@ public class PlanService {
             parent.addChildAfter(t, after);
             after = t;
         }
+        return parent;
+    }
+
+    public PlanMessage mutateTreeForMessage(List<Long> ids, Long parentId, Long afterId) {
+        mutateTree(ids, parentId, afterId);
         val m = new PlanMessage();
         m.setType("tree-mutation");
         m.setInfo(new MutatePlanTree(ids, parentId, afterId));

--- a/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
@@ -353,8 +353,17 @@ public class PlanService {
         return m;
     }
 
-    public PlanMessage setItemStatus(Long id, PlanItemStatus status) {
-        if (PlanItemStatus.COMPLETED.equals(status) || PlanItemStatus.DELETED.equals(status)) {
+    public PlanItem setItemStatus(Long id, PlanItemStatus status) {
+        PlanItem item = getPlanItemById(id, AccessLevel.CHANGE);
+        if (status.isForDelete()) {
+            item.moveToTrash();
+        }
+        item.setStatus(status);
+        return item;
+    }
+
+    public PlanMessage setItemStatusForMessage(Long id, PlanItemStatus status) {
+        if (status.isForDelete()) {
             return deleteItemForMessage(id);
         }
         PlanItem item = getPlanItemById(id, AccessLevel.CHANGE);

--- a/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
@@ -151,15 +151,20 @@ public class PlanService {
         return m;
     }
 
-    public PlanMessage resetSubitems(Long id, List<Long> subitemIds) {
-        PlanItem t = getPlanItemById(id, AccessLevel.CHANGE);
+    public PlanItem resetSubitems(Long id, List<Long> subitemIds) {
+        PlanItem item = getPlanItemById(id, AccessLevel.CHANGE);
         PlanItem prev = null;
         for (Long sid : subitemIds) {
             PlanItem curr = getPlanItemById(sid);
-            t.addChildAfter(curr, prev);
+            item.addChildAfter(curr, prev);
             prev = curr;
         }
-        return buildUpdateMessage(t);
+        return item;
+    }
+
+    public PlanMessage resetSubitemsForMessage(Long id, List<Long> subitemIds) {
+        PlanItem item = resetSubitems(id, subitemIds);
+        return buildUpdateMessage(item);
     }
 
     private void sendToPlan(AggregateIngredient r, PlanItem aggItem, Double scale) {

--- a/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
@@ -277,11 +277,16 @@ public class PlanService {
         return bucket;
     }
 
-    public PlanMessage updateBucket(Long planId, Long id, String name, LocalDate date) {
+    public PlanBucket updateBucket(Long planId, Long id, String name, LocalDate date) {
         getPlanById(planId, AccessLevel.ADMINISTER); // for the authorization check
         PlanBucket bucket = bucketRepo.getReferenceById(id);
         bucket.setName(name);
         bucket.setDate(date);
+        return bucket;
+    }
+
+    public PlanMessage updateBucketForMessage(Long planId, Long id, String name, LocalDate date) {
+        PlanBucket bucket = updateBucket(planId, id, name, date);
         PlanMessage m = new PlanMessage();
         m.setId(bucket.getId());
         m.setType("update-bucket");
@@ -289,11 +294,16 @@ public class PlanService {
         return m;
     }
 
-    public PlanMessage deleteBucket(Long planId, Long id) {
+    public PlanBucket deleteBucket(Long planId, Long id) {
         Plan plan = getPlanById(planId, AccessLevel.ADMINISTER);
         PlanBucket bucket = bucketRepo.getReferenceById(id);
         plan.getBuckets().remove(bucket);
         bucketRepo.delete(bucket);
+        return bucket;
+    }
+
+    public PlanMessage deleteBucketForMessage(Long planId, Long id) {
+        PlanBucket bucket = deleteBucket(planId, id);
         PlanMessage m = new PlanMessage();
         m.setId(bucket.getId());
         m.setType("delete-bucket");

--- a/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
@@ -215,6 +215,7 @@ public class PlanService {
         Plan plan = createPlan(name);
         Plan src = planRepo.getReferenceById(fromId);
         duplicateChildren(src, plan);
+        // todo: should duplicating a plan copy buckets and grants?
         return plan;
     }
 

--- a/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
@@ -127,8 +127,8 @@ public class PlanService {
         }
     }
 
-    public List<PlanItem> getTreeDeltasById(Long id, Instant cutoff) {
-        val plan = getPlanById(id, AccessLevel.VIEW);
+    public List<PlanItem> getTreeDeltasById(Long planId, Instant cutoff) {
+        val plan = getPlanById(planId, AccessLevel.VIEW);
         return Stream.concat(
                         getTreeById(plan).stream(),
                         plan.getTrashBinItems().stream()

--- a/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
@@ -355,25 +355,37 @@ public class PlanService {
 
     public PlanMessage setItemStatus(Long id, PlanItemStatus status) {
         if (PlanItemStatus.COMPLETED.equals(status) || PlanItemStatus.DELETED.equals(status)) {
-            return deleteItem(id);
+            return deleteItemForMessage(id);
         }
         PlanItem item = getPlanItemById(id, AccessLevel.CHANGE);
         item.setStatus(status);
         return buildUpdateMessage(item);
     }
 
-    public PlanMessage deleteItem(Long id) {
+    public PlanItem deleteItemForParent(Long id) {
         val item = getPlanItemById(id, AccessLevel.CHANGE);
         if (item.hasParent()) {
+            val parent = item.getParent();
             item.moveToTrash();
+            return parent;
         } else {
-            // a plan
-            itemRepo.delete(item);
+            throw new IllegalArgumentException(String.format(
+                    "ID '%s' is a plan",
+                    id));
         }
+    }
+
+    public PlanMessage deleteItemForMessage(Long id) {
+        deleteItemForParent(id);
         val m = new PlanMessage();
         m.setId(id);
         m.setType("delete");
         return m;
+    }
+
+    public void deletePlan(Long id) {
+        val plan = getPlanById(id, AccessLevel.ADMINISTER);
+        planRepo.delete(plan);
     }
 
     public void severLibraryLinks(Recipe r) {

--- a/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
@@ -245,12 +245,17 @@ public class PlanService {
         return planRepo.save(plan);
     }
 
-    public PlanMessage createItem(Object id, Long parentId, Long afterId, String name) {
+    public PlanItem createItem(Long parentId, Long afterId, String name) {
         PlanItem parent = getPlanItemById(parentId, AccessLevel.CHANGE);
         PlanItem after = afterId == null ? null : getPlanItemById(afterId, AccessLevel.VIEW);
         PlanItem item = itemRepo.save(new PlanItem(name).of(parent, after));
         itemService.autoRecognize(item);
         if (item.getId() == null) itemRepo.flush();
+        return item;
+    }
+
+    public PlanMessage createItemForMessage(Object id, Long parentId, Long afterId, String name) {
+        PlanItem item = createItem(parentId, afterId, name);
         PlanMessage m = buildCreationMessage(item);
         m.addNewId(item.getId(), id);
         return m;

--- a/src/main/java/com/brennaswitzer/cookbook/util/ShareHelper.java
+++ b/src/main/java/com/brennaswitzer/cookbook/util/ShareHelper.java
@@ -1,6 +1,9 @@
 package com.brennaswitzer.cookbook.util;
 
 import com.brennaswitzer.cookbook.config.AppProperties;
+import com.brennaswitzer.cookbook.domain.Identified;
+import com.brennaswitzer.cookbook.domain.Named;
+import com.brennaswitzer.cookbook.payload.ShareInfo;
 import io.jsonwebtoken.lang.Assert;
 import org.apache.commons.codec.digest.HmacAlgorithms;
 import org.apache.commons.codec.digest.HmacUtils;
@@ -13,6 +16,13 @@ public class ShareHelper {
     @Autowired
     private AppProperties appProperties;
 
+    public <T extends Identified & Named> ShareInfo getInfo(Class<T> clazz, T object) {
+        return new ShareInfo(object.getId(),
+                             SlugUtils.toSlug(object.getName()),
+                             getSecret(clazz,
+                                       object.getId()));
+    }
+
     public String getSecret(Class<?> clazz, Long id) {
         Assert.notNull(clazz, "Cannot generate a secret for the null class");
         Assert.notNull(id, "Cannot generate a secret for the null id");
@@ -24,6 +34,7 @@ public class ShareHelper {
         );
     }
 
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public boolean isSecretValid(Class<?> clazz, Long id, String secret) {
         Assert.notNull(clazz, "Cannot validate a secret for the null class");
         Assert.notNull(id, "Cannot validate a secret for the null id");

--- a/src/main/java/com/brennaswitzer/cookbook/util/SlugUtils.java
+++ b/src/main/java/com/brennaswitzer/cookbook/util/SlugUtils.java
@@ -10,15 +10,16 @@ public class SlugUtils {
         if (name == null || name.isBlank()) return "empty";
         String slug = name.substring(0, 1).toLowerCase() +
                 name.substring(1)
+                        .replaceAll("\\Bn't\\b", "nt")
+                        .replaceAll("(\\w)'s\\b", "$1s")
                         .replaceAll("([A-Z0-9]+)", "-$1")
                         .replaceAll("[^a-zA-Z0-9]+", "-")
                         .toLowerCase();
         if (maxLength > 0 && slug.length() > maxLength) {
             slug = slug.substring(0, maxLength);
-            while (slug.endsWith("-")) {
-                slug = slug.substring(0, slug.length() - 1);
-            }
         }
+        slug = slug.replaceAll("-+", "-");
+        slug = slug.replaceAll("^-|-$", "");
         return slug;
     }
 

--- a/src/main/java/com/brennaswitzer/cookbook/web/PlanController.java
+++ b/src/main/java/com/brennaswitzer/cookbook/web/PlanController.java
@@ -228,14 +228,14 @@ public class PlanController {
                 : String.format("ID mismatch on update bucket (%s on URL, %s in action)",
                                 id,
                                 action.getId());
-        return planService.updateBucket(planId, action.getId(), action.getName(), action.getDate());
+        return planService.updateBucketForMessage(planId, action.getId(), action.getName(), action.getDate());
     }
 
     @DeleteMapping("/{planId}/buckets/{id}")
     public PlanMessage deleteBucket(
             @PathVariable("planId") long planId,
             @PathVariable("id") long id) {
-        return planService.deleteBucket(planId, id);
+        return planService.deleteBucketForMessage(planId, id);
     }
 
     // todo: this method is confused. :) it's both create and update?

--- a/src/main/java/com/brennaswitzer/cookbook/web/PlanController.java
+++ b/src/main/java/com/brennaswitzer/cookbook/web/PlanController.java
@@ -125,7 +125,7 @@ public class PlanController {
                 : String.format("ID mismatch on rename (%s on URL, %s in action)",
                                 id,
                                 action.getParentId());
-        return planService.mutateTree(action.getIds(), action.getParentId(), action.getAfterId());
+        return planService.mutateTreeForMessage(action.getIds(), action.getParentId(), action.getAfterId());
     }
 
     @PostMapping("/{id}/reorder-subitems")

--- a/src/main/java/com/brennaswitzer/cookbook/web/PlanController.java
+++ b/src/main/java/com/brennaswitzer/cookbook/web/PlanController.java
@@ -155,7 +155,10 @@ public class PlanController {
                 : String.format("ID mismatch on create (%s on URL, %s in action)",
                                 id,
                                 action.getId());
-        return planService.createItem(action.getId(), action.getParentId(), action.getAfterId(), action.getName());
+        return planService.createItemForMessage(action.getId(),
+                                                action.getParentId(),
+                                                action.getAfterId(),
+                                                action.getName());
     }
 
     @PutMapping("/{id}/rename")

--- a/src/main/java/com/brennaswitzer/cookbook/web/PlanController.java
+++ b/src/main/java/com/brennaswitzer/cookbook/web/PlanController.java
@@ -17,10 +17,10 @@ import com.brennaswitzer.cookbook.payload.AclInfo;
 import com.brennaswitzer.cookbook.payload.GrantInfo;
 import com.brennaswitzer.cookbook.payload.PlanItemCreate;
 import com.brennaswitzer.cookbook.payload.PlanItemInfo;
+import com.brennaswitzer.cookbook.payload.ShareInfo;
 import com.brennaswitzer.cookbook.repositories.UserRepository;
 import com.brennaswitzer.cookbook.services.PlanService;
 import com.brennaswitzer.cookbook.util.ShareHelper;
-import com.brennaswitzer.cookbook.util.SlugUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -37,9 +37,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 @SuppressWarnings("SpringJavaAutowiredFieldsWarningInspection")
@@ -93,16 +91,11 @@ public class PlanController {
     }
 
     @GetMapping("/{id}/share")
-    public Object getShareInfoById(
+    public ShareInfo getShareInfoById(
             @PathVariable("id") Long id
     ) {
-        Plan plan = planService.getPlanById(id);
-        Map<String, Object> result = new HashMap<>();
-        result.put("id", plan.getId());
-        result.put("slug", SlugUtils.toSlug(plan.getName()));
-        result.put("secret", shareHelper.getSecret(Plan.class,
-                                                   plan.getId()));
-        return result;
+        return shareHelper.getInfo(Plan.class,
+                                   planService.getPlanById(id));
     }
 
     @GetMapping({ "/{id}/self-and-descendants",

--- a/src/main/java/com/brennaswitzer/cookbook/web/PlanController.java
+++ b/src/main/java/com/brennaswitzer/cookbook/web/PlanController.java
@@ -186,7 +186,7 @@ public class PlanController {
                 : String.format("ID mismatch on set status (%s on URL, %s in action)",
                                 id,
                                 action.getId());
-        return planService.setItemStatus(action.getId(), action.getStatus());
+        return planService.setItemStatusForMessage(action.getId(), action.getStatus());
     }
 
     @DeleteMapping("/{planId}")

--- a/src/main/java/com/brennaswitzer/cookbook/web/PlanController.java
+++ b/src/main/java/com/brennaswitzer/cookbook/web/PlanController.java
@@ -201,7 +201,7 @@ public class PlanController {
     public void deletePlan(
             @PathVariable("planId") Long planId
     ) {
-        planService.deleteItem(planId);
+        planService.deletePlan(planId);
     }
 
     @DeleteMapping("/{planId}/{id}")
@@ -212,7 +212,7 @@ public class PlanController {
         if (!planId.equals(item.getPlan().getId())) {
             throw new IllegalArgumentException("Item belongs to a different plan");
         }
-        planService.deleteItem(id);
+        planService.deleteItemForParent(id);
     }
 
     @PostMapping("/{id}/buckets")

--- a/src/main/java/com/brennaswitzer/cookbook/web/PlanController.java
+++ b/src/main/java/com/brennaswitzer/cookbook/web/PlanController.java
@@ -167,7 +167,7 @@ public class PlanController {
                 : String.format("ID mismatch on rename (%s on URL, %s in action)",
                                 id,
                                 action.getId());
-        return planService.renameItem(action.getId(), action.getName());
+        return planService.renameItemForMessage(action.getId(), action.getName());
     }
 
     @PostMapping("/{id}/assign-bucket")
@@ -178,7 +178,7 @@ public class PlanController {
                 : String.format("ID mismatch on assign bucket (%s on URL, %s in action)",
                                 id,
                                 action.getId());
-        return planService.assignItemBucket(action.getId(), action.getBucketId());
+        return planService.assignItemBucketForMessage(action.getId(), action.getBucketId());
     }
 
     @PutMapping("/{id}/status")
@@ -216,7 +216,7 @@ public class PlanController {
     public PlanMessage createBucket(
             @PathVariable("id") long planId,
             @RequestBody CreatePlanBucket action) {
-        return planService.createBucket(planId, action.getId(), action.getName(), action.getDate());
+        return planService.createBucketForMessage(planId, action.getId(), action.getName(), action.getDate());
     }
 
     @PutMapping("/{planId}/buckets/{id}")

--- a/src/main/java/com/brennaswitzer/cookbook/web/PlanController.java
+++ b/src/main/java/com/brennaswitzer/cookbook/web/PlanController.java
@@ -136,7 +136,7 @@ public class PlanController {
                 : String.format("ID mismatch on reorder (%s on URL, %s in action)",
                                 id,
                                 action.getId());
-        return planService.resetSubitems(action.getId(), action.getSubitemIds());
+        return planService.resetSubitemsForMessage(action.getId(), action.getSubitemIds());
     }
 
     @PostMapping("/{id}")

--- a/src/main/java/com/brennaswitzer/cookbook/web/RecipeController.java
+++ b/src/main/java/com/brennaswitzer/cookbook/web/RecipeController.java
@@ -15,7 +15,6 @@ import com.brennaswitzer.cookbook.services.StorageService;
 import com.brennaswitzer.cookbook.services.indexing.IndexStats;
 import com.brennaswitzer.cookbook.services.indexing.RecipeReindexQueueService;
 import com.brennaswitzer.cookbook.util.ShareHelper;
-import com.brennaswitzer.cookbook.util.SlugUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,9 +41,7 @@ import javax.persistence.NoResultException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 @RestController
@@ -157,18 +154,13 @@ public class RecipeController {
         return ingredientMapper.recipeToInfo(recipe);
     }
 
-    @GetMapping("/share/{id}")
+    @GetMapping("/share/{id}") // todo: this should be /{id}/share
     public Object getShareInfoById(
             @PathVariable("id") Long id
     ) {
         //noinspection OptionalGetWithoutIsPresent
-        Recipe r = recipeService.findRecipeById(id).get();
-        Map<String, Object> result = new HashMap<>();
-        result.put("id", r.getId());
-        result.put("slug", SlugUtils.toSlug(r.getName()));
-        result.put("secret", shareHelper.getSecret(Recipe.class,
-                                                   r.getId()));
-        return result;
+        return shareHelper.getInfo(Recipe.class,
+                                   recipeService.findRecipeById(id).get());
     }
 
     // begin kludge (3 of 3)

--- a/src/main/resources/graphqls/__master.graphqls
+++ b/src/main/resources/graphqls/__master.graphqls
@@ -1,5 +1,6 @@
 scalar Date
 scalar DateTime
+scalar Long
 scalar PositiveInt
 scalar NonNegativeInt
 scalar NonNegativeFloat

--- a/src/main/resources/graphqls/__master.graphqls
+++ b/src/main/resources/graphqls/__master.graphqls
@@ -39,3 +39,9 @@ type PageInfo {
     """
     endCursor: Cursor
 }
+
+type ShareInfo {
+    id: ID!
+    slug: String!
+    secret: String!
+}

--- a/src/main/resources/graphqls/planner.graphqls
+++ b/src/main/resources/graphqls/planner.graphqls
@@ -23,6 +23,7 @@ type Plan implements Node & Owned & AccessControlled & CorePlanItem  {
     name: String!
     """A plan's plan is always itself."""
     plan: Plan!
+    share: ShareInfo
     grants: [AccessControlEntry!]!
     childCount: NonNegativeInt!
     children: [PlanItem!]!

--- a/src/main/resources/graphqls/planner.graphqls
+++ b/src/main/resources/graphqls/planner.graphqls
@@ -99,6 +99,11 @@ type PlannerMutation {
     deletePlan(id: ID!): Boolean
     """Update the name of the given plan or plan item (but not bucket)."""
     rename(id: ID!, name: String!): PlanItem!
+    """Reorder the item/plan subitems in the same order as the passed list. If
+    there are subitems not included in the list, they will not be reordered. If
+    an item under a different parent is included in the list, it will be moved
+    under this item."""
+    reorderSubitems(id:ID!, subitemIds: [ID!]!): PlanItem
     """Set the access level granted to a user w/in a plan."""
     setGrant(planId: ID!, userId: ID!, accessLevel:AccessLevel): Plan!
     """Sets the status of the given item. This will always return the updated

--- a/src/main/resources/graphqls/planner.graphqls
+++ b/src/main/resources/graphqls/planner.graphqls
@@ -74,4 +74,8 @@ type PlannerMutation {
     assignBucket(id: ID!, bucketId: ID!): PlanItem!
     """Create a new bucket w/in a plan, with an optional name and date."""
     createBucket(planId: ID!, name: String, date: Date): PlanBucket!
+    """Update a bucket w/in a plan, by setting or clearing its name and date."""
+    updateBucket(planId: ID!, bucketId: ID!, name: String, date: Date): PlanBucket!
+    """Delete a bucket from a plan."""
+    deleteBucket(planId: ID!, bucketId: ID!): Plan!
 }

--- a/src/main/resources/graphqls/planner.graphqls
+++ b/src/main/resources/graphqls/planner.graphqls
@@ -68,18 +68,23 @@ extend type Mutation {
 }
 
 type PlannerMutation {
-    """Update the name of the given plan item."""
-    rename(id: ID!, name: String!): PlanItem!
     """Assign a plan item to a bucket (in the same plan)."""
     assignBucket(id: ID!, bucketId: ID!): PlanItem!
     """Create a new bucket w/in a plan, with an optional name and date."""
     createBucket(planId: ID!, name: String, date: Date): PlanBucket!
-    """Update a bucket w/in a plan, by setting or clearing its name and date."""
-    updateBucket(planId: ID!, bucketId: ID!, name: String, date: Date): PlanBucket!
+    """Create a new item under the specified parent (which may be a plan, for
+    top-level items), after the specified peer item (null means 'at end'), and with
+    the specified name.
+    """
+    createItem(parentId:ID!, afterId:ID, name:String): PlanItem!
     """Delete a bucket from a plan."""
     deleteBucket(planId: ID!, bucketId: ID!): Plan!
-    """Set the access level granted to a user w/in a plan."""
-    setGrant(planId: ID!, userId: ID!, accessLevel:AccessLevel): Plan!
     """Deletes the grant for a user w/in a plan, if one exists."""
     deleteGrant(planId: ID!, userId: ID!): Plan!
+    """Update the name of the given plan item."""
+    rename(id: ID!, name: String!): PlanItem!
+    """Set the access level granted to a user w/in a plan."""
+    setGrant(planId: ID!, userId: ID!, accessLevel:AccessLevel): Plan!
+    """Update a bucket w/in a plan, by setting or clearing its name and date."""
+    updateBucket(planId: ID!, bucketId: ID!, name: String, date: Date): PlanBucket!
 }

--- a/src/main/resources/graphqls/planner.graphqls
+++ b/src/main/resources/graphqls/planner.graphqls
@@ -51,6 +51,7 @@ type PlanItem implements Node {
 
 type PlanBucket {
     id: ID!
+    plan: Plan!
     name: String
     date: Date
 }
@@ -60,4 +61,17 @@ enum PlanItemStatus {
     ACQUIRED
     COMPLETED
     DELETED
+}
+
+extend type Mutation {
+    planner: PlannerMutation
+}
+
+type PlannerMutation {
+    """Update the name of the given plan item."""
+    rename(id: ID!, name: String!): PlanItem!
+    """Assign a plan item to a bucket (in the same plan)."""
+    assignBucket(id: ID!, bucketId: ID!): PlanItem!
+    """Create a new bucket w/in a plan, with an optional name and date."""
+    createBucket(planId: ID!, name: String, date: Date): PlanBucket!
 }

--- a/src/main/resources/graphqls/planner.graphqls
+++ b/src/main/resources/graphqls/planner.graphqls
@@ -76,11 +76,17 @@ type PlannerMutation {
     top-level items), after the specified peer item (null means 'at end'), and with
     the specified name.
     """
-    createItem(parentId:ID!, afterId:ID, name:String): PlanItem!
+    createItem(parentId: ID!, afterId: ID, name: String!): PlanItem!
+    """Create a new empty plan."""
+    createPlan(name: String!): Plan!
+    """Create a new plan by duplicating the specified source plan."""
+    duplicatePlan(name: String!, sourcePlanId: ID!): Plan!
     """Delete a bucket from a plan."""
     deleteBucket(planId: ID!, bucketId: ID!): Plan!
     """Deletes the grant for a user w/in a plan, if one exists."""
     deleteGrant(planId: ID!, userId: ID!): Plan!
+    """Deletes the given plan, and all its related data."""
+    deletePlan(id: ID!): Boolean
     """Update the name of the given plan item."""
     rename(id: ID!, name: String!): PlanItem!
     """Set the access level granted to a user w/in a plan."""

--- a/src/main/resources/graphqls/planner.graphqls
+++ b/src/main/resources/graphqls/planner.graphqls
@@ -97,13 +97,16 @@ type PlannerMutation {
     deleteItem(id: ID!): PlanItem
     """Deletes the given plan, and all its related data."""
     deletePlan(id: ID!): Boolean
+    """Move the given items under the given parent, in order, optionally after a
+    specific item already under that parent. The parent's info is returned."""
+    mutateTree(itemIds: [ID!]!, parentId: ID!, afterId: ID): PlanItem!
     """Update the name of the given plan or plan item (but not bucket)."""
     rename(id: ID!, name: String!): PlanItem!
     """Reorder the item/plan subitems in the same order as the passed list. If
     there are subitems not included in the list, they will not be reordered. If
     an item under a different parent is included in the list, it will be moved
     under this item."""
-    reorderSubitems(id:ID!, subitemIds: [ID!]!): PlanItem
+    reorderSubitems(parentId:ID!, itemIds: [ID!]!): PlanItem
     """Set the access level granted to a user w/in a plan."""
     setGrant(planId: ID!, userId: ID!, accessLevel:AccessLevel): Plan!
     """Sets the status of the given item. This will always return the updated

--- a/src/main/resources/graphqls/planner.graphqls
+++ b/src/main/resources/graphqls/planner.graphqls
@@ -5,6 +5,9 @@ extend type Query {
 type PlannerQuery {
     plans: [Plan]!
     planItem(id: ID!): PlanItem!
+    """Retrieve all items on the given plan which have been updated since the
+    passed cutoff (expressed in milliseconds since the UNIX epoch)."""
+    updatedSince(planId: ID!, cutoff: Long): [PlanItem!]!
 }
 
 interface CorePlanItem implements Node {

--- a/src/main/resources/graphqls/planner.graphqls
+++ b/src/main/resources/graphqls/planner.graphqls
@@ -10,27 +10,30 @@ type PlannerQuery {
 interface CorePlanItem implements Node {
     id: ID!
     name: String!
-    childCount: NonNegativeInt
+    plan: Plan!
+    childCount: NonNegativeInt!
     children: [PlanItem!]!
-    descendantCount: NonNegativeInt
+    descendantCount: NonNegativeInt!
     descendants: [PlanItem!]!
 }
 
-type Plan implements Node & Owned & AccessControlled  {
+type Plan implements Node & Owned & AccessControlled & CorePlanItem  {
     id: ID!
     owner: User!
     name: String!
+    """A plan's plan is always itself."""
+    plan: Plan!
     grants: [AccessControlEntry!]!
-    childCount: NonNegativeInt
+    childCount: NonNegativeInt!
     children: [PlanItem!]!
-    descendantCount: NonNegativeInt
+    descendantCount: NonNegativeInt!
     descendants: [PlanItem!]!
-    bucketCount: NonNegativeInt
+    bucketCount: NonNegativeInt!
     buckets: [PlanBucket!]!
 }
 
 """Represents a single item on a plan"""
-type PlanItem implements Node {
+type PlanItem implements Node & CorePlanItem {
     id: ID!
     name: String!
     quantity: Quantity
@@ -38,12 +41,12 @@ type PlanItem implements Node {
     notes: String
     plan: Plan!
     parent: PlanItem
-    childCount: NonNegativeInt
+    childCount: NonNegativeInt!
     children: [PlanItem!]!
-    descendantCount: NonNegativeInt
+    descendantCount: NonNegativeInt!
     descendants: [PlanItem!]!
     aggregate: PlanItem
-    componentCount: NonNegativeInt
+    componentCount: NonNegativeInt!
     components: [PlanItem!]!
     bucket: PlanBucket
     status: PlanItemStatus!
@@ -85,9 +88,11 @@ type PlannerMutation {
     deleteBucket(planId: ID!, bucketId: ID!): Plan!
     """Deletes the grant for a user w/in a plan, if one exists."""
     deleteGrant(planId: ID!, userId: ID!): Plan!
+    """Deletes an item from a plan, and return its former parent (plan or item). This operation cascades."""
+    deleteItem(id: ID!): PlanItem
     """Deletes the given plan, and all its related data."""
     deletePlan(id: ID!): Boolean
-    """Update the name of the given plan item."""
+    """Update the name of the given plan or plan item (but not bucket)."""
     rename(id: ID!, name: String!): PlanItem!
     """Set the access level granted to a user w/in a plan."""
     setGrant(planId: ID!, userId: ID!, accessLevel:AccessLevel): Plan!

--- a/src/main/resources/graphqls/planner.graphqls
+++ b/src/main/resources/graphqls/planner.graphqls
@@ -78,4 +78,8 @@ type PlannerMutation {
     updateBucket(planId: ID!, bucketId: ID!, name: String, date: Date): PlanBucket!
     """Delete a bucket from a plan."""
     deleteBucket(planId: ID!, bucketId: ID!): Plan!
+    """Set the access level granted to a user w/in a plan."""
+    setGrant(planId: ID!, userId: ID!, accessLevel:AccessLevel): Plan!
+    """Deletes the grant for a user w/in a plan, if one exists."""
+    deleteGrant(planId: ID!, userId: ID!): Plan!
 }

--- a/src/main/resources/graphqls/planner.graphqls
+++ b/src/main/resources/graphqls/planner.graphqls
@@ -1,39 +1,49 @@
 extend type Query {
-    getPlans: [Plan]
-    getPlanItem(id: ID!): PlanItem
+    planner: PlannerQuery
+}
+
+type PlannerQuery {
+    plans: [Plan]!
+    planItem(id: ID!): PlanItem!
 }
 
 interface CorePlanItem implements Node {
     id: ID!
     name: String!
+    childCount: NonNegativeInt
     children: [PlanItem!]!
+    descendantCount: NonNegativeInt
     descendants: [PlanItem!]!
 }
 
-type Plan implements Node & Owned & AccessControlled & CorePlanItem {
+type Plan implements Node & Owned & AccessControlled  {
     id: ID!
     owner: User!
     name: String!
     grants: [AccessControlEntry!]!
+    childCount: NonNegativeInt
     children: [PlanItem!]!
+    descendantCount: NonNegativeInt
     descendants: [PlanItem!]!
+    bucketCount: NonNegativeInt
     buckets: [PlanBucket!]!
 }
 
-"""
-Represents a single item on a plan
-"""
-type PlanItem implements Node & CorePlanItem {
+"""Represents a single item on a plan"""
+type PlanItem implements Node {
     id: ID!
     name: String!
-    quantity: NonNegativeFloat
-    units: String
+    quantity: Quantity
     preparation: String
     notes: String
     plan: Plan!
-    parent: PlanItem!
+    parent: PlanItem
+    childCount: NonNegativeInt
     children: [PlanItem!]!
+    descendantCount: NonNegativeInt
     descendants: [PlanItem!]!
+    aggregate: PlanItem
+    componentCount: NonNegativeInt
     components: [PlanItem!]!
     bucket: PlanBucket
     status: PlanItemStatus!
@@ -42,7 +52,7 @@ type PlanItem implements Node & CorePlanItem {
 type PlanBucket {
     id: ID!
     name: String
-    date: Date!
+    date: Date
 }
 
 enum PlanItemStatus {

--- a/src/main/resources/graphqls/planner.graphqls
+++ b/src/main/resources/graphqls/planner.graphqls
@@ -92,7 +92,8 @@ type PlannerMutation {
     deleteBucket(planId: ID!, bucketId: ID!): Plan!
     """Deletes the grant for a user w/in a plan, if one exists."""
     deleteGrant(planId: ID!, userId: ID!): Plan!
-    """Deletes an item from a plan, and return its former parent (plan or item). This operation cascades."""
+    """Deletes an item from a plan, and return its former parent (plan or item).
+    This operation cascades."""
     deleteItem(id: ID!): PlanItem
     """Deletes the given plan, and all its related data."""
     deletePlan(id: ID!): Boolean
@@ -100,6 +101,9 @@ type PlannerMutation {
     rename(id: ID!, name: String!): PlanItem!
     """Set the access level granted to a user w/in a plan."""
     setGrant(planId: ID!, userId: ID!, accessLevel:AccessLevel): Plan!
+    """Sets the status of the given item. This will always return the updated
+    item, though it may immediately moved to the trash (in the background)."""
+    setStatus(id: ID!, status: PlanItemStatus!): PlanItem!
     """Update a bucket w/in a plan, by setting or clearing its name and date."""
     updateBucket(planId: ID!, bucketId: ID!, name: String, date: Date): PlanBucket!
 }

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
@@ -133,6 +133,20 @@ class PlannerMutationTest extends MockTest {
     }
 
     @Test
+    void mutateTree() {
+        List<Long> itemIds = Arrays.asList(456L, 789L);
+        long parentId = 123L;
+        long afterId = 999L;
+        PlanItem parent = mock(PlanItem.class);
+        when(planService.mutateTree(itemIds, parentId, afterId))
+                .thenReturn(parent);
+
+        PlanItem result = mutation.mutateTree(itemIds, parentId, afterId);
+
+        assertSame(parent, result);
+    }
+
+    @Test
     void rename() {
         long id = 123L;
         String newName = "goat log";
@@ -147,13 +161,13 @@ class PlannerMutationTest extends MockTest {
 
     @Test
     void reorderSubitems() {
-        long id = 123L;
-        List<Long> subIds = Arrays.asList(456L, 789L);
+        long parentId = 123L;
+        List<Long> itemIds = Arrays.asList(456L, 789L);
         PlanItem parent = mock(PlanItem.class);
-        when(planService.resetSubitems(id, subIds))
+        when(planService.resetSubitems(parentId, itemIds))
                 .thenReturn(parent);
 
-        PlanItem result = mutation.reorderSubitems(id, subIds);
+        PlanItem result = mutation.reorderSubitems(parentId, itemIds);
 
         assertSame(parent, result);
     }

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
@@ -1,0 +1,65 @@
+package com.brennaswitzer.cookbook.graphql;
+
+import com.brennaswitzer.cookbook.domain.PlanBucket;
+import com.brennaswitzer.cookbook.domain.PlanItem;
+import com.brennaswitzer.cookbook.services.PlanService;
+import com.brennaswitzer.cookbook.util.MockTest;
+import com.brennaswitzer.cookbook.util.MockTestTarget;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PlannerMutationTest extends MockTest {
+
+    @MockTestTarget
+    private PlannerMutation mutation;
+
+    @Mock
+    private PlanService planService;
+
+    @Test
+    void assignBucket() {
+        long itemId = 123L;
+        long bucketId = 456L;
+        PlanItem mock = mock(PlanItem.class);
+        when(planService.assignItemBucket(itemId, bucketId))
+                .thenReturn(mock);
+
+        PlanItem item = mutation.assignBucket(itemId, bucketId);
+
+        assertSame(mock, item);
+    }
+
+    @Test
+    void createBucket() {
+        long planId = 123L;
+        String name = "bucket";
+        LocalDate date = LocalDate.of(2023, 12, 27);
+        PlanBucket mock = mock(PlanBucket.class);
+        when(planService.createBucket(planId, name, date))
+                .thenReturn(mock);
+
+        PlanBucket bucket = mutation.createBucket(planId, name, date);
+
+        assertSame(mock, bucket);
+    }
+
+    @Test
+    void rename() {
+        long id = 123L;
+        String newName = "goat log";
+        PlanItem mock = mock(PlanItem.class);
+        when(planService.renameItem(id, newName))
+                .thenReturn(mock);
+
+        PlanItem item = mutation.rename(id, newName);
+
+        assertSame(mock, item);
+    }
+
+}

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
@@ -1,5 +1,6 @@
 package com.brennaswitzer.cookbook.graphql;
 
+import com.brennaswitzer.cookbook.domain.AccessLevel;
 import com.brennaswitzer.cookbook.domain.Plan;
 import com.brennaswitzer.cookbook.domain.PlanBucket;
 import com.brennaswitzer.cookbook.domain.PlanItem;
@@ -76,6 +77,33 @@ class PlannerMutationTest extends MockTest {
         PlanItem item = mutation.rename(id, newName);
 
         assertSame(mock, item);
+    }
+
+    @Test
+    void setGrant() {
+        long planId = 123L;
+        long userId = 456L;
+        AccessLevel level = AccessLevel.CHANGE;
+        Plan plan = mock(Plan.class);
+        when(planService.setGrantOnPlan(planId, userId, level))
+                .thenReturn(plan);
+
+        Plan result = mutation.setGrant(planId, userId, level);
+
+        assertSame(plan, result);
+    }
+
+    @Test
+    void removeGrant() {
+        long planId = 123L;
+        long userId = 456L;
+        Plan plan = mock(Plan.class);
+        when(planService.deleteGrantFromPlan(planId, userId))
+                .thenReturn(plan);
+
+        Plan result = mutation.deleteGrant(planId, userId);
+
+        assertSame(plan, result);
     }
 
     @Test

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
@@ -42,13 +42,27 @@ class PlannerMutationTest extends MockTest {
         long planId = 123L;
         String name = "bucket";
         LocalDate date = LocalDate.of(2023, 12, 27);
-        PlanBucket mock = mock(PlanBucket.class);
+        PlanBucket bucket = mock(PlanBucket.class);
         when(planService.createBucket(planId, name, date))
-                .thenReturn(mock);
+                .thenReturn(bucket);
 
-        PlanBucket bucket = mutation.createBucket(planId, name, date);
+        PlanBucket result = mutation.createBucket(planId, name, date);
 
-        assertSame(mock, bucket);
+        assertSame(bucket, result);
+    }
+
+    @Test
+    void createItem() {
+        long parentId = 123L;
+        long afterId = 456L;
+        String name = "cheese";
+        PlanItem item = mock(PlanItem.class);
+        when(planService.createItem(parentId, afterId, name))
+                .thenReturn(item);
+
+        PlanItem result = mutation.createItem(parentId, afterId, name);
+
+        assertSame(item, result);
     }
 
     @Test

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
@@ -13,7 +13,9 @@ import org.mockito.Mock;
 import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class PlannerMutationTest extends MockTest {
@@ -66,6 +68,18 @@ class PlannerMutationTest extends MockTest {
     }
 
     @Test
+    void createPlan() {
+        String name = "cheese party";
+        Plan plan = mock(Plan.class);
+        when(planService.createPlan(name))
+                .thenReturn(plan);
+
+        Plan result = mutation.createPlan(name);
+
+        assertSame(plan, result);
+    }
+
+    @Test
     void deleteBucket() {
         long planId = 123L;
         long bucketId = 456L;
@@ -76,6 +90,29 @@ class PlannerMutationTest extends MockTest {
                 .thenReturn(bucket);
 
         Plan result = mutation.deleteBucket(planId, bucketId);
+
+        assertSame(plan, result);
+    }
+
+    @Test
+    void deletePlan() {
+        long planId = 123L;
+
+        boolean result = mutation.deletePlan(planId);
+
+        assertTrue(result);
+        verify(planService).deleteItem(planId);
+    }
+
+    @Test
+    void duplicatePlan() {
+        String name = "cheese party";
+        long sourcePlanId = 456L;
+        Plan plan = mock(Plan.class);
+        when(planService.duplicatePlan(name, sourcePlanId))
+                .thenReturn(plan);
+
+        Plan result = mutation.duplicatePlan(name, sourcePlanId);
 
         assertSame(plan, result);
     }

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
@@ -1,5 +1,6 @@
 package com.brennaswitzer.cookbook.graphql;
 
+import com.brennaswitzer.cookbook.domain.Plan;
 import com.brennaswitzer.cookbook.domain.PlanBucket;
 import com.brennaswitzer.cookbook.domain.PlanItem;
 import com.brennaswitzer.cookbook.services.PlanService;
@@ -50,6 +51,21 @@ class PlannerMutationTest extends MockTest {
     }
 
     @Test
+    void deleteBucket() {
+        long planId = 123L;
+        long bucketId = 456L;
+        Plan plan = mock(Plan.class);
+        PlanBucket bucket = mock(PlanBucket.class);
+        when(bucket.getPlan()).thenReturn(plan);
+        when(planService.deleteBucket(planId, bucketId))
+                .thenReturn(bucket);
+
+        Plan result = mutation.deleteBucket(planId, bucketId);
+
+        assertSame(plan, result);
+    }
+
+    @Test
     void rename() {
         long id = 123L;
         String newName = "goat log";
@@ -60,6 +76,21 @@ class PlannerMutationTest extends MockTest {
         PlanItem item = mutation.rename(id, newName);
 
         assertSame(mock, item);
+    }
+
+    @Test
+    void updateBucket() {
+        long planId = 123L;
+        long bucketId = 456L;
+        String name = "bucket";
+        LocalDate date = LocalDate.of(2023, 12, 28);
+        PlanBucket mock = mock(PlanBucket.class);
+        when(planService.updateBucket(planId, bucketId, name, date))
+                .thenReturn(mock);
+
+        PlanBucket bucket = mutation.updateBucket(planId, bucketId, name, date);
+
+        assertSame(mock, bucket);
     }
 
 }

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -134,13 +136,26 @@ class PlannerMutationTest extends MockTest {
     void rename() {
         long id = 123L;
         String newName = "goat log";
-        PlanItem mock = mock(PlanItem.class);
+        PlanItem item = mock(PlanItem.class);
         when(planService.renameItem(id, newName))
-                .thenReturn(mock);
+                .thenReturn(item);
 
-        PlanItem item = mutation.rename(id, newName);
+        PlanItem result = mutation.rename(id, newName);
 
-        assertSame(mock, item);
+        assertSame(item, result);
+    }
+
+    @Test
+    void reorderSubitems() {
+        long id = 123L;
+        List<Long> subIds = Arrays.asList(456L, 789L);
+        PlanItem parent = mock(PlanItem.class);
+        when(planService.resetSubitems(id, subIds))
+                .thenReturn(parent);
+
+        PlanItem result = mutation.reorderSubitems(id, subIds);
+
+        assertSame(parent, result);
     }
 
     @Test

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
@@ -95,13 +95,25 @@ class PlannerMutationTest extends MockTest {
     }
 
     @Test
+    void deleteItem() {
+        long itemId = 123L;
+        PlanItem parent = mock(PlanItem.class);
+        when(planService.deleteItemForParent(itemId))
+                .thenReturn(parent);
+
+        PlanItem result = mutation.deleteItem(itemId);
+
+        assertSame(parent, result);
+    }
+
+    @Test
     void deletePlan() {
         long planId = 123L;
 
         boolean result = mutation.deletePlan(planId);
 
         assertTrue(result);
-        verify(planService).deleteItem(planId);
+        verify(planService).deletePlan(planId);
     }
 
     @Test

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
@@ -4,6 +4,7 @@ import com.brennaswitzer.cookbook.domain.AccessLevel;
 import com.brennaswitzer.cookbook.domain.Plan;
 import com.brennaswitzer.cookbook.domain.PlanBucket;
 import com.brennaswitzer.cookbook.domain.PlanItem;
+import com.brennaswitzer.cookbook.domain.PlanItemStatus;
 import com.brennaswitzer.cookbook.services.PlanService;
 import com.brennaswitzer.cookbook.util.MockTest;
 import com.brennaswitzer.cookbook.util.MockTestTarget;
@@ -154,6 +155,19 @@ class PlannerMutationTest extends MockTest {
         Plan result = mutation.setGrant(planId, userId, level);
 
         assertSame(plan, result);
+    }
+
+    @Test
+    void setStatus() {
+        long id = 123L;
+        PlanItemStatus status = PlanItemStatus.ACQUIRED;
+        PlanItem item = mock(PlanItem.class);
+        when(planService.setItemStatus(id, status))
+                .thenReturn(item);
+
+        PlanItem result = mutation.setStatus(id, status);
+
+        assertSame(item, result);
     }
 
     @Test

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerQueryTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerQueryTest.java
@@ -1,0 +1,68 @@
+package com.brennaswitzer.cookbook.graphql;
+
+import com.brennaswitzer.cookbook.domain.Plan;
+import com.brennaswitzer.cookbook.domain.PlanItem;
+import com.brennaswitzer.cookbook.services.PlanService;
+import com.brennaswitzer.cookbook.util.MockTest;
+import com.brennaswitzer.cookbook.util.MockTestTarget;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PlannerQueryTest extends MockTest {
+
+    @MockTestTarget
+    private PlannerQuery query;
+
+    @Mock
+    private PlanService planService;
+
+    @Test
+    void plans() {
+        Plan a = mock(Plan.class);
+        when(a.getName()).thenReturn("A");
+        Plan b = mock(Plan.class);
+        when(b.getName()).thenReturn("B");
+        when(planService.getPlans())
+                .thenReturn(Arrays.asList(a, b));
+
+        var ps = query.plans();
+
+        assertEquals(2, ps.size());
+        assertEach(Arrays.asList("A", "B"), ps, Plan::getName);
+        verify(planService).getPlans();
+    }
+
+    @Test
+    void planItem() {
+        PlanItem it = mock(PlanItem.class);
+        when(planService.getPlanItemById(any())).thenReturn(it);
+
+        var pi = query.planItem(123L);
+
+        assertSame(pi, it);
+        verify(planService).getPlanItemById(123L);
+    }
+
+    private <O, V> void assertEach(List<V> expected, List<O> objects, Function<O, V> extractor) {
+        assertEquals(expected.size(), objects.size());
+        var ei = expected.iterator();
+        var oi = objects.iterator();
+        for (int i = 0; ei.hasNext(); i++) {
+            assertEquals(ei.next(),
+                         extractor.apply(oi.next()),
+                         String.format("Values didn't match at %s", i));
+        }
+    }
+
+}

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerQueryTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerQueryTest.java
@@ -8,6 +8,8 @@ import com.brennaswitzer.cookbook.util.MockTestTarget;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
@@ -52,6 +54,18 @@ class PlannerQueryTest extends MockTest {
 
         assertSame(pi, it);
         verify(planService).getPlanItemById(123L);
+    }
+
+    @Test
+    void updatedSince() {
+        List<PlanItem> list = new ArrayList<>();
+        when(planService.getTreeDeltasById(123L,
+                                           Instant.EPOCH.plusMillis(456)))
+                .thenReturn(list);
+
+        List<PlanItem> result = query.updatedSince(123L, 456L);
+
+        assertSame(list, result);
     }
 
     private <O, V> void assertEach(List<V> expected, List<O> objects, Function<O, V> extractor) {

--- a/src/test/java/com/brennaswitzer/cookbook/resolvers/PlanItemResolverTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/resolvers/PlanItemResolverTest.java
@@ -1,0 +1,98 @@
+package com.brennaswitzer.cookbook.resolvers;
+
+import com.brennaswitzer.cookbook.domain.Plan;
+import com.brennaswitzer.cookbook.domain.PlanItem;
+import com.brennaswitzer.cookbook.services.PlanService;
+import com.brennaswitzer.cookbook.util.MockTest;
+import com.brennaswitzer.cookbook.util.MockTestTarget;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PlanItemResolverTest extends MockTest {
+
+    @MockTestTarget
+    private PlanItemResolver resolver;
+
+    @Mock
+    private PlanService planService;
+
+    @Test
+    void parent_plan() {
+        Plan plan = mock(Plan.class);
+        when(plan.getParent()).thenReturn(null);
+        when(plan.getPlan()).thenReturn(plan);
+
+        PlanItem p = resolver.parent(plan);
+
+        assertNull(p, "Plan don't have parents");
+    }
+
+    @Test
+    void parent_item() {
+        Plan plan = mock(Plan.class);
+        PlanItem item = mock(PlanItem.class);
+        when(item.getParent()).thenReturn(plan);
+        when(item.getPlan()).thenReturn(plan);
+
+        PlanItem p = resolver.parent(item);
+
+        assertSame(plan, p);
+    }
+
+    @Test
+    void children() {
+        PlanItem item = mock(PlanItem.class);
+        List<PlanItem> kids = new ArrayList<>();
+        when(item.getOrderedChildView()).thenReturn(kids);
+
+        assertSame(kids, resolver.children(item));
+    }
+
+    @Test
+    void components() {
+        PlanItem item = mock(PlanItem.class);
+        List<PlanItem> comps = new ArrayList<>();
+        when(item.getOrderedComponentsView()).thenReturn(comps);
+
+        assertSame(comps, resolver.components(item));
+    }
+
+    @Test
+    void descendantCount() {
+        PlanItem item = mock(PlanItem.class);
+        PlanItem kid = mock(PlanItem.class);
+        when(planService.getTreeById(item))
+                .thenReturn(Arrays.asList(item, kid));
+
+        int dc = resolver.descendantCount(item);
+
+        assertEquals(1, dc);
+        verify(planService).getTreeById(item);
+    }
+
+    @Test
+    void descendants() {
+        PlanItem item = mock(PlanItem.class);
+        PlanItem kid = mock(PlanItem.class);
+        when(planService.getTreeById(item))
+                .thenReturn(Arrays.asList(item, kid));
+
+        List<PlanItem> ds = resolver.descendants(item);
+
+        assertEquals(singletonList(kid), ds);
+        verify(planService).getTreeById(item);
+    }
+
+}

--- a/src/test/java/com/brennaswitzer/cookbook/resolvers/PlanResolverTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/resolvers/PlanResolverTest.java
@@ -5,9 +5,11 @@ import com.brennaswitzer.cookbook.domain.Acl;
 import com.brennaswitzer.cookbook.domain.Plan;
 import com.brennaswitzer.cookbook.domain.PlanItem;
 import com.brennaswitzer.cookbook.domain.User;
+import com.brennaswitzer.cookbook.payload.ShareInfo;
 import com.brennaswitzer.cookbook.services.PlanService;
 import com.brennaswitzer.cookbook.util.MockTest;
 import com.brennaswitzer.cookbook.util.MockTestTarget;
+import com.brennaswitzer.cookbook.util.ShareHelper;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
@@ -30,6 +32,9 @@ class PlanResolverTest extends MockTest {
 
     @Mock
     private PlanService planService;
+
+    @Mock
+    private ShareHelper shareHelper;
 
     @Test
     void grants() {
@@ -80,6 +85,18 @@ class PlanResolverTest extends MockTest {
 
         assertEquals(singletonList(kid), ds);
         verify(planService).getTreeById(plan);
+    }
+
+    @Test
+    void share() {
+        Plan plan = mock(Plan.class);
+        ShareInfo info = mock(ShareInfo.class);
+        when(shareHelper.getInfo(Plan.class, plan))
+                .thenReturn(info);
+
+        ShareInfo result = resolver.share(plan);
+
+        assertSame(info, result);
     }
 
 }

--- a/src/test/java/com/brennaswitzer/cookbook/resolvers/PlanResolverTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/resolvers/PlanResolverTest.java
@@ -1,0 +1,85 @@
+package com.brennaswitzer.cookbook.resolvers;
+
+import com.brennaswitzer.cookbook.domain.AccessLevel;
+import com.brennaswitzer.cookbook.domain.Acl;
+import com.brennaswitzer.cookbook.domain.Plan;
+import com.brennaswitzer.cookbook.domain.PlanItem;
+import com.brennaswitzer.cookbook.domain.User;
+import com.brennaswitzer.cookbook.services.PlanService;
+import com.brennaswitzer.cookbook.util.MockTest;
+import com.brennaswitzer.cookbook.util.MockTestTarget;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PlanResolverTest extends MockTest {
+
+    @MockTestTarget
+    private PlanResolver resolver;
+
+    @Mock
+    private PlanService planService;
+
+    @Test
+    void grants() {
+        User johann = mock(User.class);
+        Acl acl = mock(Acl.class);
+        when(acl.getGrants()).thenReturn(singletonMap(johann, AccessLevel.CHANGE));
+        Plan plan = mock(Plan.class);
+        when(plan.getAcl()).thenReturn(acl);
+
+        List<AccessControlEntry> aces = resolver.grants(plan);
+
+        assertEquals(1, aces.size());
+        AccessControlEntry ace = aces.get(0);
+        assertSame(johann, ace.user);
+        assertEquals(AccessLevel.CHANGE, ace.level);
+    }
+
+    @Test
+    void children() {
+        Plan plan = mock(Plan.class);
+        List<PlanItem> kids = new ArrayList<>();
+        when(plan.getOrderedChildView()).thenReturn(kids);
+
+        assertSame(kids, resolver.children(plan));
+    }
+
+    @Test
+    void descendantCount() {
+        Plan plan = mock(Plan.class);
+        PlanItem kid = mock(PlanItem.class);
+        when(planService.getTreeById(plan))
+                .thenReturn(Arrays.asList(plan, kid));
+
+        int dc = resolver.descendantCount(plan);
+
+        assertEquals(1, dc);
+        verify(planService).getTreeById(plan);
+    }
+
+    @Test
+    void descendants() {
+        Plan plan = mock(Plan.class);
+        PlanItem kid = mock(PlanItem.class);
+        when(planService.getTreeById(plan))
+                .thenReturn(Arrays.asList(plan, kid));
+
+        List<PlanItem> ds = resolver.descendants(plan);
+
+        assertEquals(singletonList(kid), ds);
+        verify(planService).getTreeById(plan);
+    }
+
+}

--- a/src/test/java/com/brennaswitzer/cookbook/services/PlanServiceTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/services/PlanServiceTest.java
@@ -127,7 +127,7 @@ class PlanServiceTest {
         Plan plan = planRepo.save(new Plan(alice, "root"));
         PlanItem bill = itemRepo.save(new PlanItem("bill").of(plan));
 
-        service.renameItem(bill.getId(), "William");
+        service.renameItemForMessage(bill.getId(), "William");
         itemRepo.flush();
         entityManager.clear();
 

--- a/src/test/java/com/brennaswitzer/cookbook/services/PlanServiceTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/services/PlanServiceTest.java
@@ -147,14 +147,14 @@ class PlanServiceTest {
 
         assertEquals(4, itemRepo.count());
 
-        service.deleteItem(oj.getId());
+        service.deleteItemForParent(oj.getId());
         itemRepo.flush();
         entityManager.clear();
 
         assertEquals(4, itemRepo.count());
         assertEquals(3, itemRepo.countByStatusNot(PlanItemStatus.DELETED));
 
-        service.deleteItem(groceries.getId());
+        service.deletePlan(groceries.getId());
         itemRepo.flush();
         entityManager.clear();
 

--- a/src/test/java/com/brennaswitzer/cookbook/services/PlanServiceTreeMutationTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/services/PlanServiceTreeMutationTest.java
@@ -158,7 +158,7 @@ public class PlanServiceTreeMutationTest {
     }
 
     private void mutate(PlanItem parent, PlanItem after, PlanItem... items) {
-        service.mutateTree(
+        service.mutateTreeForMessage(
                 Arrays.stream(items).map(PlanItem::getId).collect(Collectors.toList()),
                 parent.getId(),
                 after == null ? null : after.getId());

--- a/src/test/java/com/brennaswitzer/cookbook/util/MockTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/util/MockTest.java
@@ -1,0 +1,101 @@
+package com.brennaswitzer.cookbook.util;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.spy;
+
+/**
+ * I will autowire-by-name any {@link Mock @Mock} collaborators defined on the
+ * test class into the {@link MockTestTarget @MockTestTarget} defined on the
+ * test class. The latter will be initialized via its class's default
+ * constructor if its value is null. It will be wrapped with as a Mockito
+ * {@link org.mockito.Mockito#spy}, whether pre- or implicitly initialized.
+ *
+ * <pre>{@code
+ * @MockTestTarget
+ * private PlanResolver resolver;
+ * @Mock
+ * private PlanService planService;
+ * }</pre>
+ *
+ * <p>The {@code resolver} field will be initialized via {@code PlanResolver}'s
+ * default constructor. The mocked {@code PlanService} will be injected into
+ * {@code resolver}'s {@code planService} field. The resolver will be wrapped
+ * with a {@code spy()}.
+ *
+ * <p>The initialization and wrapping of the target happens per <em>test</em>,
+ * not per class. If you want to initialize it yourself, you must override
+ * {@link #setup()} and initialize it before the {@code super.setup()} call, not
+ * in the field declaration itself.
+ */
+public abstract class MockTest {
+
+    private Field cutField;
+
+    private Collection<Field> collabFields;
+
+    private AutoCloseable closeable;
+
+    @BeforeEach
+    public void setup() throws ReflectiveOperationException {
+        closeable = MockitoAnnotations.openMocks(this);
+        if (cutField == null) {
+            for (Field f : getClass().getDeclaredFields()) {
+                if (f.isAnnotationPresent(MockTestTarget.class)) {
+                    cutField = f;
+                    break;
+                }
+            }
+        }
+        if (cutField == null) return;
+        Object cut = ReflectionTestUtils.getField(this, cutField.getName());
+        if (cut == null) {
+            cut = cutField.getType().getDeclaredConstructor().newInstance();
+        }
+        if (collabFields == null) {
+            List<Field> cfs = new ArrayList<>();
+            Map<String, Field> byName = new HashMap<>();
+            for (Field f : cut.getClass().getDeclaredFields()) {
+                if (Modifier.isStatic(f.getModifiers())) continue;
+                if (!f.isAnnotationPresent(Autowired.class)) continue;
+                byName.put(f.getName(), f);
+            }
+            for (Field f : getClass().getDeclaredFields()) {
+                if (!f.isAnnotationPresent(Mock.class)) continue;
+                Field cf = byName.get(f.getName());
+                if (cf == null) continue;
+                cfs.add(cf);
+            }
+            collabFields = cfs;
+        }
+        for (Field cf : collabFields) {
+            Object m = ReflectionTestUtils.getField(this, cf.getName());
+            ReflectionTestUtils.setField(cut, cf.getName(), m);
+        }
+        ReflectionTestUtils.setField(this,
+                                     cutField.getName(),
+                                     spy(cut));
+    }
+
+    @AfterEach
+    public void teardown() throws Exception {
+        closeable.close();
+        if (cutField != null) {
+            ReflectionTestUtils.setField(this, cutField.getName(), null);
+        }
+    }
+
+}

--- a/src/test/java/com/brennaswitzer/cookbook/util/MockTestTarget.java
+++ b/src/test/java/com/brennaswitzer/cookbook/util/MockTestTarget.java
@@ -1,0 +1,13 @@
+package com.brennaswitzer.cookbook.util;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Indicates the test target / component under test for a {@link MockTest}
+ * subtype, which should be wired up with {@link org.mockito.Mock @Mock}-ed
+ * collaborators from other instance fields.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MockTestTarget {
+}

--- a/src/test/java/com/brennaswitzer/cookbook/util/ShareHelperTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/util/ShareHelperTest.java
@@ -1,0 +1,41 @@
+package com.brennaswitzer.cookbook.util;
+
+import com.brennaswitzer.cookbook.domain.Identified;
+import com.brennaswitzer.cookbook.domain.Named;
+import com.brennaswitzer.cookbook.payload.ShareInfo;
+import lombok.Value;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doReturn;
+
+class ShareHelperTest extends MockTest {
+
+    @MockTestTarget
+    private ShareHelper helper;
+
+    @Value
+    private static class Shareable implements Identified, Named {
+
+        Long id;
+        String name;
+
+    }
+
+    @Test
+    void getInfo() {
+        long id = 123L;
+        String secret = "secret";
+        doReturn(secret)
+                .when(helper)
+                .getSecret(Shareable.class, id);
+
+        ShareInfo info = helper.getInfo(Shareable.class,
+                                        new Shareable(id, "A Thinger!"));
+
+        assertEquals(id, info.getId());
+        assertEquals("a-thinger", info.getSlug());
+        assertEquals(secret, info.getSecret());
+    }
+
+}

--- a/src/test/java/com/brennaswitzer/cookbook/util/SlugUtilsTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/util/SlugUtilsTest.java
@@ -28,4 +28,12 @@ public class SlugUtilsTest {
         assertEquals("team", toSlug("TeamUSA", 5));
     }
 
+    @Test
+    void punctuation() {
+        assertEquals("i-cant-sleep", toSlug("I can't sleep"));
+        assertEquals("eat-at-joes", toSlug("Eat, at Joe's"));
+        assertEquals("eat-at-joes", toSlug("Eat, at Joe's!"));
+        assertEquals("eat-at-joes-yo", toSlug("Eat, at Joe's, yo!"));
+    }
+
 }


### PR DESCRIPTION
Add GraphQL queries and mutations equivalent to the current `PlanController` endpoints

The client schema updates are in folded-ear/gobrennas-client#67