### PR TITLE
Throw an error when a recipe isn't found

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/graphql/LibraryQuery.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/LibraryQuery.java
@@ -11,6 +11,7 @@ import graphql.relay.Connection;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import javax.persistence.NoResultException;
 import java.util.Optional;
 
 @SuppressWarnings("unused") // reflected by java-graphql
@@ -37,8 +38,9 @@ public class LibraryQuery {
         throw new UnsupportedOperationException("library.pantryItem is not supported.");
     }
 
-    public Optional<Recipe> getRecipeById(Long id) {
-        return recipeService.findRecipeById(id);
+    public Recipe getRecipeById(Long id) {
+        return recipeService.findRecipeById(id)
+                .orElseThrow(() -> new NoResultException("There is no recipe with id: " + id));
     }
 
 }

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/LibraryQueryTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/LibraryQueryTest.java
@@ -1,0 +1,40 @@
+package com.brennaswitzer.cookbook.graphql;
+
+import com.brennaswitzer.cookbook.domain.Recipe;
+import com.brennaswitzer.cookbook.services.RecipeService;
+import com.brennaswitzer.cookbook.util.MockTest;
+import com.brennaswitzer.cookbook.util.MockTestTarget;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import javax.persistence.NoResultException;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LibraryQueryTest extends MockTest {
+
+    @MockTestTarget
+    private LibraryQuery query;
+
+    @Mock
+    private RecipeService recipeService;
+
+    @Test
+    void testNoRecipeById() {
+        when(recipeService.findRecipeById(any())).thenReturn(Optional.empty());
+        assertThrows(NoResultException.class, () -> query.getRecipeById(4L));
+    }
+
+    @Test
+    void testGetRecipeById() {
+        Recipe recipe = mock(Recipe.class);
+        when(recipeService.findRecipeById(any())).thenReturn(Optional.of(recipe));
+        assertSame(recipe, query.getRecipeById(4L));
+    }
+
+}


### PR DESCRIPTION
In reference to https://github.com/folded-ear/gobrennas-client/issues/71 -- the 404 will only show now when an explicit error is thrown from the API. This PR adds a `NoResultException` which will trigger the `404` in the client.