### PR TITLE
Support item recognition via the GraphQL API

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/domain/Item.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/Item.java
@@ -4,7 +4,7 @@ package com.brennaswitzer.cookbook.domain;
  * Describes a single, atomic unit for a recipe, which could be
  * something like "3 oz Parmesan, shredded" or "2 each Pizza Dough, thawed".
  * The important thing is that the Item has structured information
- * about its amount, unit, ingredient reference and also "other things
+ * about its quantity, unit, ingredient reference and also "other things
  * a cook might need to know" - quantified reference to an ingredient
  */
 public interface Item {
@@ -16,8 +16,8 @@ public interface Item {
     String getRaw();
 
     /**
-     * Amount and unit pair that describes the "how much"
-     * @return amount/unit pair
+     * Quantity and unit pair that describes the "how much"
+     * @return quantity/unit pair
      */
     Quantity getQuantity();
 

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/LibraryQuery.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/LibraryQuery.java
@@ -48,11 +48,11 @@ public class LibraryQuery {
     }
 
     public RecognizedItem recognizeItem(String raw, Integer cursor) {
-        if (cursor == null) {
-            cursor = raw.length();
-        }
         // never request suggestions, so the resolver can process 'count'
-        return itemService.recognizeItem(raw, cursor, false);
+        return itemService.recognizeItem(
+                raw,
+                cursor == null ? raw.length() : cursor,
+                false);
     }
 
 }

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/LibraryQuery.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/LibraryQuery.java
@@ -4,22 +4,25 @@ import com.brennaswitzer.cookbook.domain.PantryItem;
 import com.brennaswitzer.cookbook.domain.Recipe;
 import com.brennaswitzer.cookbook.graphql.model.OffsetConnection;
 import com.brennaswitzer.cookbook.graphql.model.OffsetConnectionCursor;
+import com.brennaswitzer.cookbook.payload.RecognizedItem;
 import com.brennaswitzer.cookbook.repositories.SearchResponse;
 import com.brennaswitzer.cookbook.repositories.impl.LibrarySearchScope;
+import com.brennaswitzer.cookbook.services.ItemService;
 import com.brennaswitzer.cookbook.services.RecipeService;
 import graphql.relay.Connection;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.persistence.NoResultException;
-import java.util.Optional;
 
-@SuppressWarnings("unused") // reflected by java-graphql
 @Component
 public class LibraryQuery {
 
     @Autowired
     private RecipeService recipeService;
+
+    @Autowired
+    private ItemService itemService;
 
     public Connection<Recipe> recipes(
             LibrarySearchScope scope,
@@ -34,6 +37,7 @@ public class LibraryQuery {
         return new OffsetConnection<>(rs);
     }
 
+    @SuppressWarnings("unused")
     public PantryItem pantryItem() {
         throw new UnsupportedOperationException("library.pantryItem is not supported.");
     }
@@ -41,6 +45,14 @@ public class LibraryQuery {
     public Recipe getRecipeById(Long id) {
         return recipeService.findRecipeById(id)
                 .orElseThrow(() -> new NoResultException("There is no recipe with id: " + id));
+    }
+
+    public RecognizedItem recognizeItem(String raw, Integer cursor) {
+        if (cursor == null) {
+            cursor = raw.length();
+        }
+        // never request suggestions, so the resolver can process 'count'
+        return itemService.recognizeItem(raw, cursor, false);
     }
 
 }

--- a/src/main/java/com/brennaswitzer/cookbook/payload/RawIngredientDissection.java
+++ b/src/main/java/com/brennaswitzer/cookbook/payload/RawIngredientDissection.java
@@ -1,26 +1,36 @@
 package com.brennaswitzer.cookbook.payload;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
+import lombok.Value;
 
 import javax.validation.constraints.NotNull;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 @Setter
 @Getter
+@EqualsAndHashCode
+@ToString
 public class RawIngredientDissection {
 
     // this is "duplicated" as processRecognizedItem
     public static RawIngredientDissection fromRecognizedItem(RecognizedItem it) {
-        Optional<RecognizedItem.Range> qr = it.getRanges().stream()
-                .filter(r -> RecognizedItem.Type.AMOUNT.equals(r.getType()))
+        Optional<RecognizedRange> qr = it.getRanges().stream()
+                .filter(r -> RecognizedRangeType.QUANTITY == r.getType())
                 .findFirst();
-        Optional<RecognizedItem.Range> ur = it.getRanges().stream()
-                .filter(r -> RecognizedItem.Type.UNIT.equals(r.getType()) || RecognizedItem.Type.NEW_UNIT.equals(r.getType()))
+        Optional<RecognizedRange> ur = it.getRanges().stream()
+                .filter(r -> RecognizedRangeType.UNIT == r.getType()
+                        || RecognizedRangeType.NEW_UNIT == r.getType())
                 .findFirst();
-        Optional<RecognizedItem.Range> nr = it.getRanges().stream()
-                .filter(r -> RecognizedItem.Type.ITEM.equals(r.getType()) || RecognizedItem.Type.NEW_ITEM.equals(r.getType()))
+        Optional<RecognizedRange> nr = it.getRanges().stream()
+                .filter(r -> RecognizedRangeType.ITEM == r.getType()
+                        || RecognizedRangeType.NEW_ITEM == r.getType())
                 .findFirst();
 
         Function<String, String> stripMarkers = s -> {
@@ -32,7 +42,7 @@ public class RawIngredientDissection {
             return s.substring(1, s.length() - 1);
         };
 
-        Function<Optional<RecognizedItem.Range>, Section> sectionFromRange = or ->
+        Function<Optional<RecognizedRange>, Section> sectionFromRange = or ->
                 or.map(r -> new Section(
                                 stripMarkers.apply(
                                         it.getRaw().substring(r.getStart(), r.getEnd())),
@@ -41,14 +51,14 @@ public class RawIngredientDissection {
                         )
                         .orElse(null);
 
-        List<Optional<RecognizedItem.Range>> ranges = new ArrayList<>(3);
+        List<Optional<RecognizedRange>> ranges = new ArrayList<>(3);
         ranges.add(qr);
         ranges.add(ur);
         ranges.add(nr);
         String p = ranges.stream()
                 .filter(Optional::isPresent)
                 .map(Optional::get)
-                .sorted(Comparator.comparingInt(RecognizedItem.Range::getStart).reversed())
+                .sorted(Comparator.comparingInt(RecognizedRange::getStart).reversed())
                 .sequential()
                 .reduce(
                         it.getRaw(),
@@ -112,92 +122,12 @@ public class RawIngredientDissection {
         this.prep = prep == null || prep.isEmpty() ? null : prep;
     }
 
+    @Value
     public static class Section {
-        private int start;
-        private int end;
-        private String text;
 
-        public Section() {
-        }
-
-        public Section(String text, int start, int end) {
-            this.text = text;
-            this.start = start;
-            this.end = end;
-        }
-
-        public int getStart() {
-            return start;
-        }
-
-        public void setStart(int start) {
-            this.start = start;
-        }
-
-        public int getEnd() {
-            return end;
-        }
-
-        public void setEnd(int end) {
-            this.end = end;
-        }
-
-        public String getText() {
-            return text;
-        }
-
-        public void setText(String text) {
-            this.text = text;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof Section)) return false;
-            Section section = (Section) o;
-            return start == section.start &&
-                    end == section.end &&
-                    text.equals(section.text);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(start, end, text);
-        }
-
-        @Override
-        public String toString() {
-            return "Section{" + "start=" + start +
-                    ", end=" + end +
-                    ", text='" + text + '\'' +
-                    '}';
-        }
+        String text;
+        int start;
+        int end;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof RawIngredientDissection)) return false;
-        RawIngredientDissection that = (RawIngredientDissection) o;
-        return raw.equals(that.raw) &&
-                Objects.equals(quantity, that.quantity) &&
-                Objects.equals(units, that.units) &&
-                Objects.equals(name, that.name) &&
-                Objects.equals(prep, that.prep);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(raw, quantity, units, name, prep);
-    }
-
-    @Override
-    public String toString() {
-        return "RawIngredientDissection{" + "raw='" + raw + '\'' +
-                ", quantity=" + quantity +
-                ", units=" + units +
-                ", name=" + name +
-                ", prep='" + prep + '\'' +
-                '}';
-    }
 }

--- a/src/main/java/com/brennaswitzer/cookbook/payload/RecognitionSuggestion.java
+++ b/src/main/java/com/brennaswitzer/cookbook/payload/RecognitionSuggestion.java
@@ -1,0 +1,28 @@
+package com.brennaswitzer.cookbook.payload;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.Comparator;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
+public class RecognitionSuggestion {
+
+    public static Comparator<RecognitionSuggestion> BY_POSITION = Comparator.comparing(a -> a.target,
+                                                                                       RecognizedRange.BY_POSITION);
+    public static Comparator<RecognitionSuggestion> BY_POSITION_AND_NAME = BY_POSITION.thenComparing(a -> a.name,
+                                                                                                     String.CASE_INSENSITIVE_ORDER);
+
+    private String name;
+    private RecognizedRange target;
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/payload/RecognizedItem.java
+++ b/src/main/java/com/brennaswitzer/cookbook/payload/RecognizedItem.java
@@ -1,9 +1,15 @@
 package com.brennaswitzer.cookbook.payload;
 
 import com.brennaswitzer.cookbook.util.EnglishUtils;
-import lombok.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
-import java.util.*;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 @NoArgsConstructor
 @EqualsAndHashCode
@@ -11,16 +17,14 @@ import java.util.*;
 public class RecognizedItem {
 
     @Getter
-    @Setter
     private String raw;
 
     @Getter
-    @Setter
     private int cursor;
 
-    private Set<Range> ranges;
+    private Set<RecognizedRange> ranges;
 
-    private Set<Suggestion> suggestions;
+    private Set<RecognitionSuggestion> suggestions;
 
     public RecognizedItem(String raw) {
         this(raw, raw.length());
@@ -31,121 +35,26 @@ public class RecognizedItem {
         this.cursor = Math.min(Math.max(cursor, 0), raw.length());
     }
 
-    public enum Type {
-        UNKNOWN,
-        AMOUNT,
-        UNIT,
-        NEW_UNIT,
-        ITEM,
-        NEW_ITEM,
-    }
-
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Getter
-    @Setter
-    @EqualsAndHashCode
-    @ToString
-    public static class Range {
-
-        public static Comparator<Range> BY_POSITION = Comparator.comparingInt(a -> a.start);
-
-        private int start;
-        private int end;
-        private Type type;
-        @EqualsAndHashCode.Exclude
-        private Object value;
-
-        public Range(int start, int end) {
-            this(start, end, Type.UNKNOWN);
-        }
-
-        public Range(int start, int end, Type type) {
-            this.start = start;
-            this.end = end;
-            this.type = type;
-        }
-
-        public Range of(Type type) {
-            return new Range(
-                    getStart(),
-                    getEnd(),
-                    type
-            );
-        }
-
-        public Range merge(Range other) {
-            return new Range(
-                    getStart(),
-                    other.getEnd()
-            );
-        }
-
-        @SuppressWarnings("RedundantIfStatement")
-        public boolean overlaps(Range r) {
-            // this wraps r
-            if (this.start <= r.start && this.end >= r.end) return true;
-            // this is inside r
-            if (this.start >= r.start && this.end <= r.end) return true;
-            // this spans r's start
-            if (this.start <= r.start && this.end >= r.start) return true;
-            // this spans r's end
-            if (this.start <= r.end && this.end >= r.end) return true;
-            // no overlap
-            return false;
-        }
-
-        public Range withValue(Object value) {
-            setValue(value);
-            return this;
-        }
-
-    }
-
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Getter
-    @Setter
-    @EqualsAndHashCode
-    @ToString
-    public static class Suggestion {
-
-        public static Comparator<Suggestion> BY_POSITION = Comparator.comparingInt(a -> a.target.start);
-        public static Comparator<Suggestion> BY_POSITION_AND_NAME = BY_POSITION.thenComparing(a -> a.name, String.CASE_INSENSITIVE_ORDER);
-
-        private String name;
-        private Range target;
-
-    }
-
-    public Set<Range> getRanges() {
+    public Set<RecognizedRange> getRanges() {
         if (ranges == null) {
-            ranges = new TreeSet<>(Range.BY_POSITION);
+            ranges = new TreeSet<>(RecognizedRange.BY_POSITION);
         }
         return ranges;
     }
 
-    public void setRanges(Set<Range> ranges) {
-        this.ranges = ranges;
-    }
-
-    public Set<Suggestion> getSuggestions() {
+    public Set<RecognitionSuggestion> getSuggestions() {
         if (suggestions == null) {
-            suggestions = new TreeSet<>(Suggestion.BY_POSITION_AND_NAME);
+            suggestions = new TreeSet<>(RecognitionSuggestion.BY_POSITION_AND_NAME);
         }
         return suggestions;
     }
 
-    public void setSuggestions(Set<Suggestion> suggestions) {
-        this.suggestions = suggestions;
-    }
-
-    public RecognizedItem withRange(Range r) {
+    public RecognizedItem withRange(RecognizedRange r) {
         getRanges().add(r);
         return this;
     }
 
-    public RecognizedItem withSuggestion(Suggestion c) {
+    public RecognizedItem withSuggestion(RecognitionSuggestion c) {
         getSuggestions().add(c);
         return this;
     }
@@ -154,26 +63,26 @@ public class RecognizedItem {
      * I return an Iterable over all the words in the raw string which have not
      * been recognized yet.
      */
-    public Iterable<Range> unrecognizedWords() {
+    public Iterable<RecognizedRange> unrecognizedWords() {
         return unrecognizedWords(raw);
     }
 
-    public Iterable<Range> unrecognizedWordsThrough(int endIndex) {
+    public Iterable<RecognizedRange> unrecognizedWordsThrough(int endIndex) {
         return unrecognizedWords(raw.substring(0, endIndex));
     }
 
-    private Iterable<Range> unrecognizedWords(String raw) {
-        List<Range> result = new LinkedList<>();
+    private Iterable<RecognizedRange> unrecognizedWords(String raw) {
+        List<RecognizedRange> result = new LinkedList<>();
         String[] words = raw.split(" ");
         int pos = 0;
         for (String w : words) {
             String c = EnglishUtils.canonicalize(w);
-            Range r;
+            RecognizedRange r;
             if (w.equals(c)) {
-                r = new Range(pos, pos + w.length());
+                r = new RecognizedRange(pos, pos + w.length());
             } else {
                 int start = w.indexOf(c);
-                r = new Range(
+                r = new RecognizedRange(
                         pos + start,
                         pos + start + c.length()
                 );

--- a/src/main/java/com/brennaswitzer/cookbook/payload/RecognizedRange.java
+++ b/src/main/java/com/brennaswitzer/cookbook/payload/RecognizedRange.java
@@ -36,11 +36,15 @@ public class RecognizedRange {
     }
 
     public RecognizedRange of(RecognizedRangeType type) {
-        return new RecognizedRange(
-                getStart(),
-                getEnd(),
-                type
-        );
+        return new RecognizedRange(start, end, type);
+    }
+
+    public String of(String raw) {
+        return raw.substring(start, end);
+    }
+
+    public int length() {
+        return end - start;
     }
 
     public RecognizedRange merge(RecognizedRange other) {

--- a/src/main/java/com/brennaswitzer/cookbook/payload/RecognizedRange.java
+++ b/src/main/java/com/brennaswitzer/cookbook/payload/RecognizedRange.java
@@ -1,0 +1,77 @@
+package com.brennaswitzer.cookbook.payload;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.Comparator;
+
+@NoArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
+public class RecognizedRange {
+
+    public static Comparator<RecognizedRange> BY_POSITION = Comparator.comparingInt(a -> a.start);
+
+    private int start;
+    private int end;
+    private RecognizedRangeType type;
+    @EqualsAndHashCode.Exclude
+    private Double quantity;
+    @EqualsAndHashCode.Exclude
+    private Long id;
+
+    public RecognizedRange(int start, int end) {
+        this(start, end, RecognizedRangeType.UNKNOWN);
+    }
+
+    public RecognizedRange(int start, int end, RecognizedRangeType type) {
+        this.start = start;
+        this.end = end;
+        this.type = type;
+    }
+
+    public RecognizedRange of(RecognizedRangeType type) {
+        return new RecognizedRange(
+                getStart(),
+                getEnd(),
+                type
+        );
+    }
+
+    public RecognizedRange merge(RecognizedRange other) {
+        return new RecognizedRange(
+                getStart(),
+                other.getEnd()
+        );
+    }
+
+    @SuppressWarnings("RedundantIfStatement")
+    public boolean overlaps(RecognizedRange r) {
+        // this wraps r
+        if (this.start <= r.start && this.end >= r.end) return true;
+        // this is inside r
+        if (this.start >= r.start && this.end <= r.end) return true;
+        // this spans r's start
+        if (this.start <= r.start && this.end >= r.start) return true;
+        // this spans r's end
+        if (this.start <= r.end && this.end >= r.end) return true;
+        // no overlap
+        return false;
+    }
+
+    public RecognizedRange withQuantity(Double quantity) {
+        setQuantity(quantity);
+        return this;
+    }
+
+    public RecognizedRange withId(Long id) {
+        setId(id);
+        return this;
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/payload/RecognizedRangeType.java
+++ b/src/main/java/com/brennaswitzer/cookbook/payload/RecognizedRangeType.java
@@ -1,0 +1,10 @@
+package com.brennaswitzer.cookbook.payload;
+
+public enum RecognizedRangeType {
+    UNKNOWN,
+    QUANTITY,
+    UNIT,
+    NEW_UNIT,
+    ITEM,
+    NEW_ITEM,
+}

--- a/src/main/java/com/brennaswitzer/cookbook/resolvers/RecognizedItemResolver.java
+++ b/src/main/java/com/brennaswitzer/cookbook/resolvers/RecognizedItemResolver.java
@@ -1,0 +1,23 @@
+package com.brennaswitzer.cookbook.resolvers;
+
+import com.brennaswitzer.cookbook.payload.RecognitionSuggestion;
+import com.brennaswitzer.cookbook.payload.RecognizedItem;
+import com.brennaswitzer.cookbook.services.ItemService;
+import graphql.kickstart.tools.GraphQLResolver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@SuppressWarnings("unused") // component-scanned for graphql-java
+@Component
+public class RecognizedItemResolver implements GraphQLResolver<RecognizedItem> {
+
+    @Autowired
+    private ItemService itemService;
+
+    public List<RecognitionSuggestion> suggestions(RecognizedItem item, int count) {
+        return itemService.getSuggestions(item, count);
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/services/ItemService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/ItemService.java
@@ -36,16 +36,6 @@ public class ItemService {
     @Autowired
     private IngredientService ingredientService;
 
-    public RecognizedItem recognizeItem(String raw) {
-        if (raw == null) return null;
-        // if no cursor location is specified, assume it's at the end
-        return recognizeItem(raw, raw.length());
-    }
-
-    public RecognizedItem recognizeItem(String raw, int cursor) {
-        return recognizeItem(raw, cursor, true);
-    }
-
     public RecognizedItem recognizeItem(String raw, int cursor, boolean withSuggestions) {
         if (raw == null) return null;
         if (raw.trim().isEmpty()) return null;
@@ -194,7 +184,7 @@ public class ItemService {
         if (it == null) return;
         String raw = it.getRaw();
         if (raw == null || raw.trim().isEmpty()) return;
-        RecognizedItem recog = recognizeItem(raw);
+        RecognizedItem recog = recognizeItem(raw, raw.length(), false);
         if (recog == null) return;
         RawIngredientDissection dissection = RawIngredientDissection
                 .fromRecognizedItem(recog);

--- a/src/main/java/com/brennaswitzer/cookbook/web/ItemController.java
+++ b/src/main/java/com/brennaswitzer/cookbook/web/ItemController.java
@@ -18,7 +18,7 @@ public class ItemController {
 
     @PostMapping("/recognize")
     public RecognizedItem recognizeItem(@RequestBody ItemToRecognize item) {
-        return service.recognizeItem(item.getRaw(), item.getCursor());
+        return service.recognizeItem(item.getRaw(), item.getCursor(), true);
     }
 
 }

--- a/src/main/resources/graphqls/library.graphqls
+++ b/src/main/resources/graphqls/library.graphqls
@@ -31,11 +31,72 @@ type LibraryQuery {
     """Please ignore; I exist because GraphQL defines the available types as
     those reachable from fields. Since PantryItem is currently only used
     polymorphically (e.g., by `Query`'s `node` field), it will not be included
-    in the available types.
+    in the available types without this dummy field.
     """
     pantryItem: PantryItem
 
     getRecipeById(id: ID!): Recipe
+
+    """Recognize quantity, unit, and/or ingredient in a raw ingredient ref (aka
+    item) string, and describe that structure. By default, also provide
+    suggestions based on partial matches.
+    """
+    recognizeItem(
+        """The raw string to recognize.
+        """
+        raw: String!
+        """The position of the cursor in the raw string, used to make contextual
+        suggestions. If not specified, the end of the raw string is assumed.
+        """
+        cursor: NonNegativeInt
+    ): RecognizedItem
+}
+
+"""The result of recognizing a raw ingredient ref item.
+"""
+type RecognizedItem {
+    """The raw string which was recognized.
+    """
+    raw: String!
+    """The position of the cursor in the raw string.
+    """
+    cursor: NonNegativeInt!
+    """Recognized ranges within the raw string.
+    """
+    ranges: [RecognizedRange!]!
+    """Suggestions of what the user might wish to insert at the current cursor
+    position. If more than 'count' suggestions are available, the returned
+    subset is unspecified, other than pantry items are preferred to recipes.
+    """
+    suggestions(count: PositiveInt! = 10): [RecognitionSuggestion!]!
+}
+
+enum RecognizedRangeType {
+    UNKNOWN
+    QUANTITY
+    UNIT
+    NEW_UNIT
+    ITEM
+    NEW_ITEM
+}
+
+"""A recognized quantity in the raw string. The type indicates which of the id
+or quantity fields will be non-null, if either.
+"""
+type RecognizedRange {
+    start: NonNegativeInt!
+    end: NonNegativeInt!
+    type: RecognizedRangeType!
+    quantity: NonNegativeFloat
+    id: ID
+}
+
+"""A suggestion for what might come next at the cursor position, along with the
+target range of the raw string it would replace.
+"""
+type RecognitionSuggestion {
+    name: String!
+    target: RecognizedRange!
 }
 
 type RecipeConnection {

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/LibraryQueryTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/LibraryQueryTest.java
@@ -1,6 +1,8 @@
 package com.brennaswitzer.cookbook.graphql;
 
 import com.brennaswitzer.cookbook.domain.Recipe;
+import com.brennaswitzer.cookbook.payload.RecognizedItem;
+import com.brennaswitzer.cookbook.services.ItemService;
 import com.brennaswitzer.cookbook.services.RecipeService;
 import com.brennaswitzer.cookbook.util.MockTest;
 import com.brennaswitzer.cookbook.util.MockTestTarget;
@@ -8,12 +10,13 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import javax.persistence.NoResultException;
-
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class LibraryQueryTest extends MockTest {
@@ -23,6 +26,8 @@ class LibraryQueryTest extends MockTest {
 
     @Mock
     private RecipeService recipeService;
+    @Mock
+    private ItemService itemService;
 
     @Test
     void testNoRecipeById() {
@@ -35,6 +40,23 @@ class LibraryQueryTest extends MockTest {
         Recipe recipe = mock(Recipe.class);
         when(recipeService.findRecipeById(any())).thenReturn(Optional.of(recipe));
         assertSame(recipe, query.getRecipeById(4L));
+    }
+
+    @Test
+    void recognizeItem_cursor() {
+        query.recognizeItem("goat", 14);
+        verify(itemService).recognizeItem("goat", 14, false);
+    }
+
+    @Test
+    void recognizeItem_noCursor() {
+        var mock = mock(RecognizedItem.class);
+        when(itemService.recognizeItem("goat", 4, false))
+                .thenReturn(mock);
+
+        var result = query.recognizeItem("goat", null);
+
+        assertSame(mock, result);
     }
 
 }

--- a/src/test/java/com/brennaswitzer/cookbook/payload/RecognizedItemTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/payload/RecognizedItemTest.java
@@ -4,8 +4,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 
-import static com.brennaswitzer.cookbook.payload.RecognizedItem.Range;
-import static com.brennaswitzer.cookbook.payload.RecognizedItem.Type;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -14,20 +12,20 @@ public class RecognizedItemTest {
     @Test
     public void zeroRangeIterator() {
         RecognizedItem el = new RecognizedItem("1 cup flour");
-        Iterator<Range> itr = el.unrecognizedWords().iterator();
-        assertEquals(new Range(0, 1), itr.next());
-        assertEquals(new Range(2, 5), itr.next());
-        assertEquals(new Range(6, 11), itr.next());
+        Iterator<RecognizedRange> itr = el.unrecognizedWords().iterator();
+        assertEquals(new RecognizedRange(0, 1), itr.next());
+        assertEquals(new RecognizedRange(2, 5), itr.next());
+        assertEquals(new RecognizedRange(6, 11), itr.next());
         assertFalse(itr.hasNext());
     }
 
     @Test
     public void iteratorWithRanges() {
         RecognizedItem el = new RecognizedItem("1 _cup_ flour");
-        el.withRange(new Range(2, 5, Type.NEW_UNIT));
-        Iterator<Range> itr = el.unrecognizedWords().iterator();
-        assertEquals(new Range(0, 1), itr.next());
-        assertEquals(new Range(8, 13), itr.next());
+        el.withRange(new RecognizedRange(2, 5, RecognizedRangeType.NEW_UNIT));
+        Iterator<RecognizedRange> itr = el.unrecognizedWords().iterator();
+        assertEquals(new RecognizedRange(0, 1), itr.next());
+        assertEquals(new RecognizedRange(8, 13), itr.next());
         assertFalse(itr.hasNext());
     }
 

--- a/src/test/java/com/brennaswitzer/cookbook/services/ItemServiceTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/services/ItemServiceTest.java
@@ -1,6 +1,9 @@
 package com.brennaswitzer.cookbook.services;
 
+import com.brennaswitzer.cookbook.payload.RecognitionSuggestion;
 import com.brennaswitzer.cookbook.payload.RecognizedItem;
+import com.brennaswitzer.cookbook.payload.RecognizedRange;
+import com.brennaswitzer.cookbook.payload.RecognizedRangeType;
 import com.brennaswitzer.cookbook.util.RecipeBox;
 import com.brennaswitzer.cookbook.util.UserPrincipalAccess;
 import com.brennaswitzer.cookbook.util.WithAliceBobEve;
@@ -53,10 +56,10 @@ public class ItemServiceTest {
         System.out.println(el);
 
         assertEquals(RAW, el.getRaw());
-        Iterator<RecognizedItem.Range> ri = el.getRanges().iterator();
-        assertEquals(new RecognizedItem.Range(0, 7, RecognizedItem.Type.AMOUNT), ri.next());
-        assertEquals(new RecognizedItem.Range(8, 11, RecognizedItem.Type.UNIT), ri.next());
-        assertEquals(new RecognizedItem.Range(24, 29, RecognizedItem.Type.ITEM), ri.next());
+        Iterator<RecognizedRange> ri = el.getRanges().iterator();
+        assertEquals(new RecognizedRange(0, 7, RecognizedRangeType.QUANTITY), ri.next());
+        assertEquals(new RecognizedRange(8, 11, RecognizedRangeType.UNIT), ri.next());
+        assertEquals(new RecognizedRange(24, 29, RecognizedRangeType.ITEM), ri.next());
         assertFalse(ri.hasNext());
     }
 
@@ -68,10 +71,10 @@ public class ItemServiceTest {
         final String RAW = "1 cup Italian seasoning";
         RecognizedItem el = service.recognizeItem(RAW);
 
-        Stream<RecognizedItem.Range> ri = el.getRanges().stream();
+        Stream<RecognizedRange> ri = el.getRanges().stream();
         //noinspection OptionalGetWithoutIsPresent
-        RecognizedItem.Range ing = ri.filter(it -> it.getType() == RecognizedItem.Type.ITEM).findFirst().get();
-        assertEquals(new RecognizedItem.Range(6, 23, RecognizedItem.Type.ITEM), ing);
+        RecognizedRange ing = ri.filter(it -> it.getType() == RecognizedRangeType.ITEM).findFirst().get();
+        assertEquals(new RecognizedRange(6, 23, RecognizedRangeType.ITEM), ing);
     }
 
     @Test
@@ -82,10 +85,10 @@ public class ItemServiceTest {
         final String RAW = "1 cup flour,";
         RecognizedItem el = service.recognizeItem(RAW);
 
-        Stream<RecognizedItem.Range> ri = el.getRanges().stream();
+        Stream<RecognizedRange> ri = el.getRanges().stream();
         //noinspection OptionalGetWithoutIsPresent
-        RecognizedItem.Range ing = ri.filter(it -> it.getType() == RecognizedItem.Type.ITEM).findFirst().get();
-        assertEquals(new RecognizedItem.Range(6, 11, RecognizedItem.Type.ITEM), ing);
+        RecognizedRange ing = ri.filter(it -> it.getType() == RecognizedRangeType.ITEM).findFirst().get();
+        assertEquals(new RecognizedRange(6, 11, RecognizedRangeType.ITEM), ing);
     }
 
     @SuppressWarnings("OptionalGetWithoutIsPresent")
@@ -99,19 +102,19 @@ public class ItemServiceTest {
 
         var q = recog.getRanges()
                 .stream()
-                .filter(r -> r.getType() == RecognizedItem.Type.AMOUNT)
+                .filter(r -> r.getType() == RecognizedRangeType.QUANTITY)
                 .findFirst()
                 .get();
         assertEquals("12", raw.substring(q.getStart(), q.getEnd()));
         var item = recog.getRanges()
                 .stream()
-                .filter(r -> r.getType() == RecognizedItem.Type.ITEM)
+                .filter(r -> r.getType() == RecognizedRangeType.ITEM)
                 .findFirst()
                 .get();
         assertEquals("flour", raw.substring(item.getStart(), item.getEnd()));
         var optUnit = recog.getRanges()
                 .stream()
-                .filter(r -> r.getType() == RecognizedItem.Type.UNIT)
+                .filter(r -> r.getType() == RecognizedRangeType.UNIT)
                 .findFirst();
         assertFalse(optUnit.isPresent());
     }
@@ -132,10 +135,10 @@ public class ItemServiceTest {
 
         System.out.println(el);
 
-        Iterator<RecognizedItem.Range> ri = el.getRanges().iterator();
-        assertEquals(new RecognizedItem.Range(0, 1, RecognizedItem.Type.AMOUNT), ri.next());
-        assertEquals(new RecognizedItem.Range(2, 5, RecognizedItem.Type.UNIT), ri.next());
-        assertEquals(new RecognizedItem.Range(6, 20, RecognizedItem.Type.ITEM), ri.next());
+        Iterator<RecognizedRange> ri = el.getRanges().iterator();
+        assertEquals(new RecognizedRange(0, 1, RecognizedRangeType.QUANTITY), ri.next());
+        assertEquals(new RecognizedRange(2, 5, RecognizedRangeType.UNIT), ri.next());
+        assertEquals(new RecognizedRange(6, 20, RecognizedRangeType.ITEM), ri.next());
         assertFalse(ri.hasNext());
     }
 
@@ -164,22 +167,22 @@ public class ItemServiceTest {
 
         // with no cursor; we're at the end
         RecognizedItem el = service.recognizeItem("1 gram f");
-        Iterator<RecognizedItem.Suggestion> itr = el.getSuggestions().iterator();
-        assertEquals(new RecognizedItem.Suggestion("flour",
-                new RecognizedItem.Range(7, 8, RecognizedItem.Type.ITEM)), itr.next());
-        assertEquals(  new RecognizedItem.Suggestion("fresh tomatoes",
-                new RecognizedItem.Range(7, 8, RecognizedItem.Type.ITEM)), itr.next());
-        assertEquals(new RecognizedItem.Suggestion("Fried Chicken",
-                new RecognizedItem.Range(7, 8, RecognizedItem.Type.ITEM)), itr.next());
+        Iterator<RecognitionSuggestion> itr = el.getSuggestions().iterator();
+        assertEquals(new RecognitionSuggestion("flour",
+                                               new RecognizedRange(7, 8, RecognizedRangeType.ITEM)), itr.next());
+        assertEquals(new RecognitionSuggestion("fresh tomatoes",
+                                               new RecognizedRange(7, 8, RecognizedRangeType.ITEM)), itr.next());
+        assertEquals(new RecognitionSuggestion("Fried Chicken",
+                                               new RecognizedRange(7, 8, RecognizedRangeType.ITEM)), itr.next());
         assertFalse(itr.hasNext());
 
         // cursor after the 'fr'
         el = service.recognizeItem("1 gram fr, dehydrated", 9);
         itr = el.getSuggestions().iterator();
-        assertEquals(new RecognizedItem.Suggestion("fresh tomatoes",
-                new RecognizedItem.Range(7, 9, RecognizedItem.Type.ITEM)), itr.next());
-        assertEquals(new RecognizedItem.Suggestion("Fried Chicken",
-                new RecognizedItem.Range(7, 9, RecognizedItem.Type.ITEM)), itr.next());
+        assertEquals(new RecognitionSuggestion("fresh tomatoes",
+                                               new RecognizedRange(7, 9, RecognizedRangeType.ITEM)), itr.next());
+        assertEquals(new RecognitionSuggestion("Fried Chicken",
+                                               new RecognizedRange(7, 9, RecognizedRangeType.ITEM)), itr.next());
     }
 
     @Test
@@ -188,9 +191,9 @@ public class ItemServiceTest {
         box.persist(entityManager, principalAccess.getUser());
         // cursor after the 'cru'
         RecognizedItem el = service.recognizeItem("1 gram \"cru, dehydrated", 11);
-        Iterator<RecognizedItem.Suggestion> itr = el.getSuggestions().iterator();
-        assertEquals(new RecognizedItem.Suggestion("Pizza Crust",
-                new RecognizedItem.Range(7, 11, RecognizedItem.Type.ITEM)), itr.next());
+        Iterator<RecognitionSuggestion> itr = el.getSuggestions().iterator();
+        assertEquals(new RecognitionSuggestion("Pizza Crust",
+                                               new RecognizedRange(7, 11, RecognizedRangeType.ITEM)), itr.next());
     }
 
     @Test
@@ -199,9 +202,9 @@ public class ItemServiceTest {
         box.persist(entityManager, principalAccess.getUser());
         // cursor after the 'cru'
         RecognizedItem el = service.recognizeItem("1 gram \"crumbs", 11);
-        Iterator<RecognizedItem.Suggestion> itr = el.getSuggestions().iterator();
-        assertEquals(new RecognizedItem.Suggestion("Pizza Crust",
-                new RecognizedItem.Range(7, 11, RecognizedItem.Type.ITEM)), itr.next());
+        Iterator<RecognitionSuggestion> itr = el.getSuggestions().iterator();
+        assertEquals(new RecognitionSuggestion("Pizza Crust",
+                                               new RecognizedRange(7, 11, RecognizedRangeType.ITEM)), itr.next());
     }
 
     @Test
@@ -210,9 +213,9 @@ public class ItemServiceTest {
         box.persist(entityManager, principalAccess.getUser());
         // cursor after the 'pizza cru'
         RecognizedItem el = service.recognizeItem("1 gram \"pizza cru, dehydrated", 17);
-        Iterator<RecognizedItem.Suggestion> itr = el.getSuggestions().iterator();
-        assertEquals(new RecognizedItem.Suggestion("Pizza Crust",
-                new RecognizedItem.Range(7, 17, RecognizedItem.Type.ITEM)), itr.next());
+        Iterator<RecognitionSuggestion> itr = el.getSuggestions().iterator();
+        assertEquals(new RecognitionSuggestion("Pizza Crust",
+                                               new RecognizedRange(7, 17, RecognizedRangeType.ITEM)), itr.next());
     }
 
     @Test
@@ -221,9 +224,9 @@ public class ItemServiceTest {
         box.persist(entityManager, principalAccess.getUser());
         // cursor after the 'pizza cru'
         RecognizedItem el = service.recognizeItem("1 gram pizza cru, dehydrated", 16);
-        Iterator<RecognizedItem.Suggestion> itr = el.getSuggestions().iterator();
-        assertEquals(new RecognizedItem.Suggestion("Pizza Crust",
-                new RecognizedItem.Range(7, 16, RecognizedItem.Type.ITEM)), itr.next());
+        Iterator<RecognitionSuggestion> itr = el.getSuggestions().iterator();
+        assertEquals(new RecognitionSuggestion("Pizza Crust",
+                                               new RecognizedRange(7, 16, RecognizedRangeType.ITEM)), itr.next());
     }
 
     @Test
@@ -233,10 +236,10 @@ public class ItemServiceTest {
 
         final String RAW = "spanish apple cake";
         RecognizedItem el = service.recognizeItem(RAW);
-        Stream<RecognizedItem.Range> ri = el.getRanges().stream();
+        Stream<RecognizedRange> ri = el.getRanges().stream();
         //noinspection OptionalGetWithoutIsPresent
-        RecognizedItem.Range ing = ri.filter(it -> it.getType() == RecognizedItem.Type.ITEM).findFirst().get();
-        assertEquals(new RecognizedItem.Range(0, 18, RecognizedItem.Type.ITEM), ing);
+        RecognizedRange ing = ri.filter(it -> it.getType() == RecognizedRangeType.ITEM).findFirst().get();
+        assertEquals(new RecognizedRange(0, 18, RecognizedRangeType.ITEM), ing);
 
     }
 

--- a/src/test/java/com/brennaswitzer/cookbook/services/ItemServiceTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/services/ItemServiceTest.java
@@ -78,6 +78,37 @@ public class ItemServiceTest {
     }
 
     @Test
+    public void recognizeItemLongestPhraseWins() {
+        RecipeBox box = new RecipeBox();
+        box.persist(entityManager, principalAccess.getUser());
+
+        final String RAW = "42 cup chicken thighs with italian seasoning";
+        RecognizedItem el = recognizeItem(RAW);
+
+        Iterator<RecognizedRange> itr = el.getRanges().iterator();
+        assertEquals("42", itr.next().of(RAW));
+        assertEquals("cup", itr.next().of(RAW));
+        assertEquals("italian seasoning", itr.next().of(RAW));
+        assertFalse(itr.hasNext());
+    }
+
+    @Test
+    public void recognizeItemFirstSameLengthPhraseWins() {
+        RecipeBox box = new RecipeBox();
+        box.persist(entityManager, principalAccess.getUser());
+
+        final String RAW = "7 cup each pizza crust and pizza sauce, blended";
+        //                             |-- 11 ---|     |-- 11 ---|
+        RecognizedItem el = recognizeItem(RAW);
+
+        Iterator<RecognizedRange> itr = el.getRanges().iterator();
+        assertEquals("7", itr.next().of(RAW));
+        assertEquals("cup", itr.next().of(RAW));
+        assertEquals("pizza crust", itr.next().of(RAW));
+        assertFalse(itr.hasNext());
+    }
+
+    @Test
     public void recognizeItemPunctuation() {
         RecipeBox box = new RecipeBox();
         box.persist(entityManager, principalAccess.getUser());

--- a/src/test/java/com/brennaswitzer/cookbook/services/ItemServiceTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/services/ItemServiceTest.java
@@ -39,11 +39,11 @@ public class ItemServiceTest {
 
     @Test
     public void whitespaces() {
-        service.recognizeItem("", 0);
-        service.recognizeItem("cat", 0);
-        service.recognizeItem("cat  ", 3);
-        service.recognizeItem(" cat", 2);
-        service.recognizeItem(" cat", 1);
+        recognizeItem("", 0);
+        recognizeItem("cat", 0);
+        recognizeItem("cat  ", 3);
+        recognizeItem(" cat", 2);
+        recognizeItem(" cat", 1);
     }
 
     @Test
@@ -52,7 +52,7 @@ public class ItemServiceTest {
         box.persist(entityManager, principalAccess.getUser());
 
         final String RAW = "3 & 1/2 cup whole wheat flour";
-        RecognizedItem el = service.recognizeItem(RAW);
+        RecognizedItem el = recognizeItem(RAW);
         System.out.println(el);
 
         assertEquals(RAW, el.getRaw());
@@ -69,7 +69,7 @@ public class ItemServiceTest {
         box.persist(entityManager, principalAccess.getUser());
 
         final String RAW = "1 cup Italian seasoning";
-        RecognizedItem el = service.recognizeItem(RAW);
+        RecognizedItem el = recognizeItem(RAW);
 
         Stream<RecognizedRange> ri = el.getRanges().stream();
         //noinspection OptionalGetWithoutIsPresent
@@ -83,7 +83,7 @@ public class ItemServiceTest {
         box.persist(entityManager, principalAccess.getUser());
 
         final String RAW = "1 cup flour,";
-        RecognizedItem el = service.recognizeItem(RAW);
+        RecognizedItem el = recognizeItem(RAW);
 
         Stream<RecognizedRange> ri = el.getRanges().stream();
         //noinspection OptionalGetWithoutIsPresent
@@ -121,8 +121,7 @@ public class ItemServiceTest {
 
     @Test
     public void recognizeItemMultipleWords() {
-        recognizeChickenThighs(raw ->
-                service.recognizeItem(raw));
+        recognizeChickenThighs(this::recognizeItem);
     }
 
     private void recognizeChickenThighs(Function<String, RecognizedItem> doRecognition) {
@@ -145,19 +144,19 @@ public class ItemServiceTest {
     @Test
     public void recognizeItemMultipleWordsWithCursorAtStart() {
         recognizeChickenThighs(raw ->
-                service.recognizeItem(raw, 0));
+                                       recognizeItem(raw, 0));
     }
 
     @Test
     public void recognizeItemMultipleWordsWithCursorBeforeSpace() {
         recognizeChickenThighs(raw ->
-                service.recognizeItem(raw, 13));
+                                       recognizeItem(raw, 13));
     }
 
     @Test
     public void recognizeItemMultipleWordsWithCursorAfterSpace() {
         recognizeChickenThighs(raw ->
-                service.recognizeItem(raw, 14));
+                                       recognizeItem(raw, 14));
     }
 
     @Test
@@ -165,8 +164,7 @@ public class ItemServiceTest {
         RecipeBox box = new RecipeBox();
         box.persist(entityManager, principalAccess.getUser());
 
-        // with no cursor; we're at the end
-        RecognizedItem el = service.recognizeItem("1 gram f");
+        RecognizedItem el = recognizeItem("1 gram f");
         Iterator<RecognitionSuggestion> itr = el.getSuggestions().iterator();
         assertEquals(new RecognitionSuggestion("flour",
                                                new RecognizedRange(7, 8, RecognizedRangeType.ITEM)), itr.next());
@@ -177,7 +175,7 @@ public class ItemServiceTest {
         assertFalse(itr.hasNext());
 
         // cursor after the 'fr'
-        el = service.recognizeItem("1 gram fr, dehydrated", 9);
+        el = recognizeItem("1 gram fr, dehydrated", 9);
         itr = el.getSuggestions().iterator();
         assertEquals(new RecognitionSuggestion("fresh tomatoes",
                                                new RecognizedRange(7, 9, RecognizedRangeType.ITEM)), itr.next());
@@ -190,7 +188,7 @@ public class ItemServiceTest {
         RecipeBox box = new RecipeBox();
         box.persist(entityManager, principalAccess.getUser());
         // cursor after the 'cru'
-        RecognizedItem el = service.recognizeItem("1 gram \"cru, dehydrated", 11);
+        RecognizedItem el = recognizeItem("1 gram \"cru, dehydrated", 11);
         Iterator<RecognitionSuggestion> itr = el.getSuggestions().iterator();
         assertEquals(new RecognitionSuggestion("Pizza Crust",
                                                new RecognizedRange(7, 11, RecognizedRangeType.ITEM)), itr.next());
@@ -201,7 +199,7 @@ public class ItemServiceTest {
         RecipeBox box = new RecipeBox();
         box.persist(entityManager, principalAccess.getUser());
         // cursor after the 'cru'
-        RecognizedItem el = service.recognizeItem("1 gram \"crumbs", 11);
+        RecognizedItem el = recognizeItem("1 gram \"crumbs", 11);
         Iterator<RecognitionSuggestion> itr = el.getSuggestions().iterator();
         assertEquals(new RecognitionSuggestion("Pizza Crust",
                                                new RecognizedRange(7, 11, RecognizedRangeType.ITEM)), itr.next());
@@ -212,7 +210,7 @@ public class ItemServiceTest {
         RecipeBox box = new RecipeBox();
         box.persist(entityManager, principalAccess.getUser());
         // cursor after the 'pizza cru'
-        RecognizedItem el = service.recognizeItem("1 gram \"pizza cru, dehydrated", 17);
+        RecognizedItem el = recognizeItem("1 gram \"pizza cru, dehydrated", 17);
         Iterator<RecognitionSuggestion> itr = el.getSuggestions().iterator();
         assertEquals(new RecognitionSuggestion("Pizza Crust",
                                                new RecognizedRange(7, 17, RecognizedRangeType.ITEM)), itr.next());
@@ -223,7 +221,7 @@ public class ItemServiceTest {
         RecipeBox box = new RecipeBox();
         box.persist(entityManager, principalAccess.getUser());
         // cursor after the 'pizza cru'
-        RecognizedItem el = service.recognizeItem("1 gram pizza cru, dehydrated", 16);
+        RecognizedItem el = recognizeItem("1 gram pizza cru, dehydrated", 16);
         Iterator<RecognitionSuggestion> itr = el.getSuggestions().iterator();
         assertEquals(new RecognitionSuggestion("Pizza Crust",
                                                new RecognizedRange(7, 16, RecognizedRangeType.ITEM)), itr.next());
@@ -235,12 +233,23 @@ public class ItemServiceTest {
         box.persist(entityManager, principalAccess.getUser());
 
         final String RAW = "spanish apple cake";
-        RecognizedItem el = service.recognizeItem(RAW);
+        RecognizedItem el = recognizeItem(RAW);
         Stream<RecognizedRange> ri = el.getRanges().stream();
         //noinspection OptionalGetWithoutIsPresent
         RecognizedRange ing = ri.filter(it -> it.getType() == RecognizedRangeType.ITEM).findFirst().get();
         assertEquals(new RecognizedRange(0, 18, RecognizedRangeType.ITEM), ing);
 
     }
+
+    private RecognizedItem recognizeItem(String raw) {
+        if (raw == null) return null;
+        // if no cursor location is specified, assume it's at the end
+        return service.recognizeItem(raw, raw.length(), true);
+    }
+
+    private RecognizedItem recognizeItem(String raw, int cursor) {
+        return service.recognizeItem(raw, cursor, true);
+    }
+
 
 }

--- a/src/test/resources/raw/dissections.txt
+++ b/src/test/resources/raw/dissections.txt
@@ -1,4 +1,4 @@
-raw|amount|astart|aend|unit|ustart|uend|name|nstart|nend
+raw|quantity|qstart|qend|unit|ustart|uend|name|nstart|nend
 1 ¾  pounds large or extra-large shrimp, shelled|1 ¾|0|3||||||
 1 cup flour|1|0|1||||||
 1 _cup_ flour|1|0|1|cup|2|7|||


### PR DESCRIPTION
Add a new field to `LibraryQuery` for recognizing an item. Finish standardizing on "quantity" (not "amount"). Move `RecognizedItem`'s nested types to the top level, to simplify java-graphql-kickstart configuration, as more of it can be done by auto-configuration. Split suggestion generation from the main item recognition, as GraphQL offers a way to talk about the two parts separately.