### PR TITLE
Docker layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,15 @@ FROM eclipse-temurin:17-alpine as build
 WORKDIR /app
 COPY . ./
 RUN ./mvnw --batch-mode verify
+RUN java -Djarmode=layertools -jar target/cookbook-1.0.0-SNAPSHOT.jar extract
 
 # server environment
 FROM eclipse-temurin:17-alpine
-COPY --from=build /app/target/cookbook-1.0.0-SNAPSHOT.jar .
+COPY --from=build /app/dependencies/ ./
+COPY --from=build /app/spring-boot-loader/ ./
+COPY --from=build /app/snapshot-dependencies/ ./
+COPY --from=build /app/application/ ./
 ENV PORT=80 \
     HOST=0.0.0.0
 EXPOSE $PORT
-CMD java -jar cookbook-1.0.0-SNAPSHOT.jar
+ENTRYPOINT ["java", "-cp", "BOOT-INF/classes:BOOT-INF/lib/*", "com.brennaswitzer.cookbook.CookbookApplication"]

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,12 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-gcp-logging</artifactId>
             <version>1.2.8.RELEASE</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION
Try a layered docker image, as well as running the app directly (without JarLauncher). The former should make for smaller images, due to layer reuse. The latter should make startup faster.