### PR TITLE
Docker layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,15 @@ FROM eclipse-temurin:17-alpine as build
 WORKDIR /app
 COPY . ./
 RUN ./mvnw --batch-mode verify
+RUN java -Djarmode=layertools -jar target/cookbook-1.0.0-SNAPSHOT.jar extract
 
 # server environment
 FROM eclipse-temurin:17-alpine
-COPY --from=build /app/target/cookbook-1.0.0-SNAPSHOT.jar .
+COPY --from=build /app/dependencies/ ./
+COPY --from=build /app/spring-boot-loader/ ./
+COPY --from=build /app/snapshot-dependencies/ ./
+COPY --from=build /app/application/ ./
 ENV PORT=80 \
     HOST=0.0.0.0
 EXPOSE $PORT
-CMD java -jar cookbook-1.0.0-SNAPSHOT.jar
+ENTRYPOINT ["java", "-cp", "BOOT-INF/classes:BOOT-INF/lib/*", "com.brennaswitzer.cookbook.CookbookApplication"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ FROM eclipse-temurin:17-alpine
 COPY --from=build /app/dependencies/ ./
 COPY --from=build /app/spring-boot-loader/ ./
 COPY --from=build /app/snapshot-dependencies/ ./
+# A no-op COPY followed by another COPY loses a layer, so add
+# a "garbage" RUN, since we generally don't have snapshot deps.
+# See https://github.com/moby/moby/issues/37965
+RUN true
 COPY --from=build /app/application/ ./
 ENV PORT=80 \
     HOST=0.0.0.0

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,12 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-gcp-logging</artifactId>
             <version>1.2.8.RELEASE</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION
use layered images, per recommendation, by splitting the deps up from the app.