### PR TITLE
edit recipe w/o a new photo clears existing photo

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/domain/S3File.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/S3File.java
@@ -17,7 +17,17 @@ public class S3File {
 
     private static final Pattern FILENAME_SANITIZER = Pattern.compile("[^a-zA-Z0-9.\\-]+");
     public static String sanitizeFilename(String filename) {
+        // Opera supplies a full path, not just a filename
+        filename = lastSegment(filename, '/');
+        filename = lastSegment(filename, '\\');
         return FILENAME_SANITIZER.matcher(filename).replaceAll("_");
+    }
+
+    private static String lastSegment(String string, char delim) {
+        int idx = string.lastIndexOf(delim);
+        return idx < 0
+                ? string
+                : string.substring(idx + 1);
     }
 
     private String objectKey;

--- a/src/main/java/com/brennaswitzer/cookbook/services/RecipeService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/RecipeService.java
@@ -41,8 +41,9 @@ public class RecipeService {
 
     public Recipe createNewRecipe(Recipe recipe, Upload photo) {
         recipe.setOwner(principalAccess.getUser());
-        setPhotoInternal(recipe, photo);
-        return recipeRepository.save(recipe);
+        recipe = recipeRepository.save(recipe);
+        if (photo != null) setPhotoInternal(recipe, photo);
+        return recipe;
     }
 
     public Recipe updateRecipe(Recipe recipe) {
@@ -51,7 +52,7 @@ public class RecipeService {
 
     public Recipe updateRecipe(Recipe recipe, Upload photo) {
         getMyRecipe(recipe.getId());
-        setPhotoInternal(recipe, photo);
+        if (photo != null) setPhotoInternal(recipe, photo);
         return recipeRepository.save(recipe);
     }
 
@@ -83,7 +84,6 @@ public class RecipeService {
 
     private void setPhotoInternal(Recipe recipe, Upload photo) {
         removePhotoInternal(recipe);
-        if (photo == null) return;
         String name = photo.getOriginalFilename();
         if (name == null) {
             name = "photo";

--- a/src/test/java/com/brennaswitzer/cookbook/domain/S3FileTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/domain/S3FileTest.java
@@ -1,0 +1,23 @@
+package com.brennaswitzer.cookbook.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class S3FileTest {
+
+    @Test
+    public void sanitizeFilename() {
+        assertEquals("goat.txt",
+                     S3File.sanitizeFilename("goat.txt"));
+        assertEquals("go_at.txt",
+                     S3File.sanitizeFilename("go$$!!at.txt"));
+        assertEquals("goat.txt",
+                     S3File.sanitizeFilename("c:\\path\\to\\goat.txt"));
+        assertEquals("goat.txt",
+                     S3File.sanitizeFilename("/path/to/goat.txt"));
+        assertEquals("go_at.txt",
+                     S3File.sanitizeFilename("/path/to/go!_at.txt"));
+    }
+
+}

--- a/src/test/java/com/brennaswitzer/cookbook/services/RecipeServiceTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/services/RecipeServiceTest.java
@@ -1,0 +1,178 @@
+package com.brennaswitzer.cookbook.services;
+
+import com.brennaswitzer.cookbook.domain.Recipe;
+import com.brennaswitzer.cookbook.domain.S3File;
+import com.brennaswitzer.cookbook.domain.Upload;
+import com.brennaswitzer.cookbook.domain.User;
+import com.brennaswitzer.cookbook.repositories.RecipeRepository;
+import com.brennaswitzer.cookbook.util.UserPrincipalAccess;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RecipeServiceTest {
+
+    @InjectMocks
+    private RecipeService service;
+
+    @Mock
+    private RecipeRepository recipeRepository;
+
+    @Mock
+    private UserPrincipalAccess principalAccess;
+
+    @Mock
+    private StorageService storageService;
+
+    @Test
+    void createNewRecipe_withPhoto() {
+        Recipe input = new Recipe();
+        Recipe saved = new Recipe();
+        long recipeId = 1234L;
+        saved.setId(recipeId);
+        Upload photo = mock(Upload.class);
+        String filename = "photo.jpg";
+        when(photo.getOriginalFilename())
+                .thenReturn(filename);
+        when(recipeRepository.save(input))
+                .thenReturn(saved);
+
+        Recipe result = service.createNewRecipe(input, photo);
+
+        assertSame(saved, result);
+        verify(storageService)
+                .store(photo,
+                       String.format("recipe/%d/%s",
+                                     recipeId,
+                                     filename));
+    }
+
+    @Test
+    void createRecipe_noPhoto() {
+        Recipe input = new Recipe();
+        Recipe saved = new Recipe();
+        when(recipeRepository.save(input))
+                .thenReturn(saved);
+
+        Recipe result = service.createNewRecipe(input);
+
+        assertSame(saved, result);
+        verifyNoInteractions(storageService);
+    }
+
+    @Test
+    void updateRecipe_addPhoto() {
+        User owner = new User();
+        long recipeId = 123L;
+        Upload photo = mock(Upload.class);
+        String filename = "photo.jpg";
+        when(photo.getOriginalFilename())
+                .thenReturn(filename);
+        Recipe saved = new Recipe();
+        saved.setId(recipeId);
+        saved.setOwner(owner);
+        when(recipeRepository.getReferenceById(recipeId))
+                .thenReturn(saved);
+        when(recipeRepository.save(saved))
+                .thenReturn(saved);
+        when(principalAccess.getUser())
+                .thenReturn(owner);
+
+        Recipe result = service.updateRecipe(saved, photo);
+
+        assertSame(saved, result);
+        verify(storageService)
+                .store(photo,
+                       String.format("recipe/%d/%s",
+                                     recipeId,
+                                     filename));
+    }
+
+    @Test
+    void updateRecipe_replacePhoto() {
+        User owner = new User();
+        Upload photo = mock(Upload.class);
+        String filename = "photo.jpg";
+        when(photo.getOriginalFilename())
+                .thenReturn(filename);
+        long recipeId = 123L;
+        Recipe saved = new Recipe();
+        saved.setId(recipeId);
+        saved.setOwner(owner);
+        String oldObjectKey = "path/to/old_photo.jpg";
+        saved.setPhoto(new S3File(oldObjectKey,
+                                  "image/jpg",
+                                  1234L));
+        when(recipeRepository.getReferenceById(recipeId))
+                .thenReturn(saved);
+        when(recipeRepository.save(saved))
+                .thenReturn(saved);
+        when(principalAccess.getUser())
+                .thenReturn(owner);
+
+        Recipe result = service.updateRecipe(saved, photo);
+
+        assertSame(saved, result);
+        verify(storageService)
+                .remove(oldObjectKey);
+        verify(storageService)
+                .store(photo,
+                       String.format("recipe/%d/%s",
+                                     recipeId,
+                                     filename));
+    }
+
+    @Test
+    void updateRecipe_leaveExistingPhoto() {
+        User owner = new User();
+        long recipeId = 123L;
+        Recipe saved = new Recipe();
+        saved.setOwner(owner);
+        saved.setId(recipeId);
+        saved.setPhoto(new S3File("path/to/photo.jpg",
+                                  "image/jpg",
+                                  1234L));
+        when(recipeRepository.getReferenceById(recipeId))
+                .thenReturn(saved);
+        when(recipeRepository.save(saved))
+                .thenReturn(saved);
+        when(principalAccess.getUser())
+                .thenReturn(owner);
+
+        Recipe result = service.updateRecipe(saved);
+
+        assertSame(saved, result);
+        verifyNoInteractions(storageService);
+    }
+
+    @Test
+    void updateRecipe_stillNoPhoto() {
+        User owner = new User();
+        long recipeId = 123L;
+        Recipe input = new Recipe();
+        input.setId(recipeId);
+        Recipe saved = new Recipe();
+        saved.setOwner(owner);
+        when(recipeRepository.getReferenceById(recipeId))
+                .thenReturn(saved);
+        when(recipeRepository.save(input))
+                .thenReturn(saved);
+        when(principalAccess.getUser())
+                .thenReturn(owner);
+
+        Recipe result = service.updateRecipe(input);
+
+        assertSame(saved, result);
+        verifyNoInteractions(storageService);
+    }
+
+}


### PR DESCRIPTION
I didn't do the graphql-ification of recipe stuff very well. The files work, but only the main happy path. Now there are a) some tests, and b) working aux paths.

closes #32 and #37