### PR TITLE
use prefix matching for unquoted search terms

### DIFF
--- a/src/test/java/com/brennaswitzer/cookbook/repositories/PostgresFullTextQueryConverterTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/repositories/PostgresFullTextQueryConverterTest.java
@@ -9,14 +9,15 @@ public class PostgresFullTextQueryConverterTest {
 
     @ParameterizedTest
     @CsvSource(quoteCharacter = '#', // we want to process single quotes
-            value = {
-                    "chicken                   , chicken",
-                    "chicken thighs            , chicken | thighs",
-                    "'chicken thighs'          , chicken <-> thighs",
-                    "\"chicken thighs\"        , chicken <-> thighs",
-                    "celery \"chicken thighs\" , celery | chicken <-> thighs",
-                    "'a b' \"c d\" e 'f \"g    , a <-> b | c <-> d | e | f | g"
-        })
+            textBlock = """
+                    chicken                 , chicken:*
+                    'chicken'               , chicken
+                    chicken thighs          , chicken:* | thighs:*
+                    'chicken thighs'        , chicken <-> thighs
+                    "chicken thighs"        , chicken <-> thighs
+                    celery "chicken thighs" , celery:* | chicken <-> thighs
+                    'a b' "c d" e 'f "g     , a <-> b | c <-> d | e:* | f:* | g:*
+                    """)
     public void filterConversion(String input, String expected) {
         String actual = new PostgresFullTextQueryConverter()
                 .convert(input);


### PR DESCRIPTION
For unquoted search terms, use prefix matching. So `chi` will match `chicken`. It's not the  same as a `LIKE '%chi%'`, in that it's still using the stemmed indexed lexemes to match on, and it's prefix-only. More concretely, `chi` will _not_ match `enchiladas`, because the search is not a prefix as it is with `chicken`. So better, but perhaps not sufficient.