### PR TITLE
Graphql item dupes

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/domain/Ingredient.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/Ingredient.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.Comparator;
 import java.util.HashSet;
@@ -44,6 +45,7 @@ public abstract class Ingredient extends BaseEntity implements Named, Labeled {
     private String name;
 
     @ElementCollection
+    @BatchSize(size = 50)
     private Set<LabelRef> labels = new HashSet<>();
 
     public Ingredient() {}

--- a/src/main/java/com/brennaswitzer/cookbook/domain/LabelRef.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/LabelRef.java
@@ -8,12 +8,12 @@ import lombok.Setter;
 
 import java.util.Objects;
 
+@Getter
+@Setter
 @Embeddable
 public class LabelRef {
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @Getter
-    @Setter
     private Label label;
 
     public LabelRef() {

--- a/src/main/java/com/brennaswitzer/cookbook/domain/PantryItem.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/PantryItem.java
@@ -10,6 +10,7 @@ import jakarta.persistence.PreUpdate;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.collection.spi.PersistentSet;
 import org.springframework.util.Assert;
 
@@ -39,6 +40,7 @@ public class PantryItem extends Ingredient {
     private int storeOrder = 0;
 
     @ElementCollection
+    @BatchSize(size = 50)
     @Column(name = "synonym")
     @Setter(AccessLevel.PRIVATE)
     private Set<String> synonyms;

--- a/src/main/java/com/brennaswitzer/cookbook/domain/PantryItem.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/PantryItem.java
@@ -49,6 +49,12 @@ public class PantryItem extends Ingredient {
      */
     private transient Long useCount;
 
+    /**
+     * I cache this item's duplicate count, but don't use me directly. Instead,
+     * use {@link PantryItemSearchRepository#countDuplicates}.
+     */
+    private transient Long duplicateCount;
+
     public PantryItem() {
     }
 

--- a/src/main/java/com/brennaswitzer/cookbook/domain/PantryItemDuplicate.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/PantryItemDuplicate.java
@@ -1,0 +1,28 @@
+package com.brennaswitzer.cookbook.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.Immutable;
+
+@Setter
+@Getter
+@Entity
+@Table(name = "pantry_item_duplicates")
+@Immutable
+public class PantryItemDuplicate {
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    PantryItem pantryItem;
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    PantryItem duplicate;
+    boolean loose;
+    float matchRank;
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/PantryQuery.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/PantryQuery.java
@@ -4,6 +4,7 @@ import com.brennaswitzer.cookbook.domain.PantryItem;
 import com.brennaswitzer.cookbook.graphql.model.OffsetConnection;
 import com.brennaswitzer.cookbook.graphql.model.OffsetConnectionCursor;
 import com.brennaswitzer.cookbook.repositories.SearchResponse;
+import com.brennaswitzer.cookbook.repositories.impl.PantryItemSearchRequest;
 import com.brennaswitzer.cookbook.repositories.impl.SortDir;
 import com.brennaswitzer.cookbook.services.PantryItemService;
 import graphql.relay.Connection;
@@ -21,16 +22,20 @@ public class PantryQuery extends PagingQuery {
 
     public Connection<PantryItem> search(
             String query,
+            Long duplicateOf,
             String sortBy,
             SortDir sortDir,
             Integer first,
             OffsetConnectionCursor after
     ) {
         SearchResponse<PantryItem> rs = pantryItemService.search(
-                query,
-                getSort(sortBy, sortDir),
-                getOffset(after),
-                getLimit(first));
+                PantryItemSearchRequest.builder()
+                        .filter(query)
+                        .duplicateOf(duplicateOf)
+                        .sort(getSort(sortBy, sortDir))
+                        .offset(getOffset(after))
+                        .limit(getLimit(first))
+                        .build());
         return new OffsetConnection<>(rs);
     }
 
@@ -41,12 +46,7 @@ public class PantryQuery extends PagingQuery {
             Integer first,
             OffsetConnectionCursor after
     ) {
-        SearchResponse<PantryItem> rs = pantryItemService.duplicatesOf(
-                itemId,
-                getSort(sortBy, sortDir),
-                getOffset(after),
-                getLimit(first));
-        return new OffsetConnection<>(rs);
+        return search(null, itemId, sortBy, sortDir, first, after);
     }
 
     private Sort getSort(String sortBy, SortDir sortDir) {

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/loaders/PantryItemDuplicateCountBatchLoader.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/loaders/PantryItemDuplicateCountBatchLoader.java
@@ -1,0 +1,25 @@
+package com.brennaswitzer.cookbook.graphql.loaders;
+
+import com.brennaswitzer.cookbook.domain.PantryItem;
+import com.brennaswitzer.cookbook.repositories.PantryItemRepository;
+import org.dataloader.BatchLoader;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+@Component
+public class PantryItemDuplicateCountBatchLoader implements BatchLoader<PantryItem, Long> {
+
+    @Autowired
+    private PantryItemRepository pantryItemRepository;
+
+    public CompletionStage<List<Long>> load(List<PantryItem> items) {
+        return CompletableFuture.supplyAsync(() -> items.stream()
+                .map(pantryItemRepository.countDuplicates(items)::get)
+                .toList());
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/model/OffsetConnection.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/model/OffsetConnection.java
@@ -19,14 +19,14 @@ public class OffsetConnection<T> implements Connection<T> {
 
     public OffsetConnection(SearchResponse<T> rs) {
         int offset = rs.getOffset();
-        edges = new ArrayList<>(rs.getSize());
+        edges = new ArrayList<>(rs.size());
         int i = 0;
         for (T r : rs.getContent()) {
             edges.add(new DefaultEdge<>(r, new OffsetConnectionCursor(offset + i++)));
         }
         pageInfo = new DefaultPageInfo(
                 rs.isEmpty() ? null : new OffsetConnectionCursor(offset),
-                rs.isEmpty() ? null : new OffsetConnectionCursor(offset + rs.getSize() - 1),
+                rs.isEmpty() ? null : new OffsetConnectionCursor(offset + rs.size() - 1),
                 rs.hasPrevious(),
                 rs.hasNext());
     }

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/resolvers/PantryItemResolver.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/resolvers/PantryItemResolver.java
@@ -2,6 +2,7 @@ package com.brennaswitzer.cookbook.graphql.resolvers;
 
 import com.brennaswitzer.cookbook.domain.Label;
 import com.brennaswitzer.cookbook.domain.PantryItem;
+import com.brennaswitzer.cookbook.graphql.loaders.PantryItemDuplicateCountBatchLoader;
 import com.brennaswitzer.cookbook.graphql.loaders.PantryItemUseCountBatchLoader;
 import graphql.kickstart.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
@@ -37,6 +38,12 @@ public class PantryItemResolver implements GraphQLResolver<PantryItem> {
     public CompletableFuture<Long> useCount(PantryItem pantryItem,
                                             DataFetchingEnvironment env) {
         return env.<PantryItem, Long>getDataLoader(PantryItemUseCountBatchLoader.class.getName())
+                .load(pantryItem);
+    }
+
+    public CompletableFuture<Long> duplicateCount(PantryItem pantryItem,
+                                                  DataFetchingEnvironment env) {
+        return env.<PantryItem, Long>getDataLoader(PantryItemDuplicateCountBatchLoader.class.getName())
                 .load(pantryItem);
     }
 

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/PantryItemSearchRepository.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/PantryItemSearchRepository.java
@@ -10,6 +10,8 @@ public interface PantryItemSearchRepository {
 
     Map<PantryItem, Long> countTotalUses(Collection<PantryItem> items);
 
+    Map<PantryItem, Long> countDuplicates(Collection<PantryItem> items);
+
     SearchResponse<PantryItem> search(PantryItemSearchRequest request);
 
 }

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/PantryItemSearchRepositoryImpl.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/PantryItemSearchRepositoryImpl.java
@@ -73,7 +73,13 @@ public class PantryItemSearchRepositoryImpl implements PantryItemSearchRepositor
     }
 
     @Override
+    public Map<PantryItem, Long> countDuplicates(Collection<PantryItem> items) {
+        return Map.of(); // todo: implement
+    }
+
+    @Override
     public SearchResponse<PantryItem> search(PantryItemSearchRequest request) {
+        // todo: consider request.duplicateOf
         var sortedByUseCount = request.isSorted()
                                && request.getSort()
                                        .stream()

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/PantryItemSearchRepositoryImpl.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/PantryItemSearchRepositoryImpl.java
@@ -1,17 +1,22 @@
 package com.brennaswitzer.cookbook.repositories;
 
+import com.brennaswitzer.cookbook.domain.Identified;
 import com.brennaswitzer.cookbook.domain.PantryItem;
 import com.brennaswitzer.cookbook.repositories.impl.PantryItemSearchRequest;
 import com.brennaswitzer.cookbook.util.EnglishUtils;
 import com.brennaswitzer.cookbook.util.NamedParameterQuery;
+import com.google.common.annotations.VisibleForTesting;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
 
 @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
 public class PantryItemSearchRepositoryImpl implements PantryItemSearchRepository {
@@ -29,23 +34,53 @@ public class PantryItemSearchRepositoryImpl implements PantryItemSearchRepositor
             )
             """;
 
+    private static final String DUPLICATE_COUNT_BY_ID =
+            """
+            (select count(*)
+             from PantryItemDuplicate
+             where pantryItem.id = %1$s
+               and not loose
+            )
+            """;
+
     @Autowired
     private EntityManager entityManager;
 
     private record IdAndCount(Long id, Long count) {}
 
-    private record ItemAndUse(PantryItem item, Long useCount) {}
+    // type shenanigans to allow Hibernate's reflective instantiation
+    private record ItemAndCounts(PantryItem item, Object useCount, Object dupeCount) {
 
-    @Override
-    public Map<PantryItem, Long> countTotalUses(Collection<PantryItem> items) {
-        Map<PantryItem, Long> result = new HashMap<>();
-        Map<Long, PantryItem> toFetchById = new HashMap<>();
+        ItemAndCounts(PantryItem item, Integer useCount, Long dupeCount) {
+            this(item, (Object) useCount, dupeCount);
+        }
+
+        ItemAndCounts(PantryItem item, Long useCount, Integer dupeCount) {
+            this(item, (Object) useCount, dupeCount);
+        }
+
+    }
+
+    @VisibleForTesting
+    Long countTotalUses(PantryItem item) {
+        return countTotalUses(Collections.singleton(item))
+                .get(item);
+    }
+
+    private <T extends Identified> Map<T, Long> countSomething(
+            Collection<T> items,
+            Function<T, Long> getter,
+            BiConsumer<T, Long> setter,
+            String countExpression) {
+        Map<T, Long> result = new HashMap<>();
+        Map<Long, T> toFetchById = new HashMap<>();
         for (var it : items) {
             if (result.containsKey(it)) continue;
-            if (it.getUseCount() == null) {
+            Long value = getter.apply(it);
+            if (value == null) {
                 toFetchById.put(it.getId(), it);
             } else {
-                result.put(it, it.getUseCount());
+                result.put(it, value);
             }
         }
         if (toFetchById.isEmpty()) return result;
@@ -55,8 +90,8 @@ public class PantryItemSearchRepositoryImpl implements PantryItemSearchRepositor
                 """)
                 .append(String.format(
                         """
-                             , %s as use_count
-                        """, String.format(USE_COUNT_BY_ID, "item.id")))
+                             , %s
+                        """, String.format(countExpression, "item.id")))
                 .append("""
                         from PantryItem item
                         where id in :ids
@@ -65,32 +100,60 @@ public class PantryItemSearchRepositoryImpl implements PantryItemSearchRepositor
                                               IdAndCount.class);
         q.forEachParameter(query::setParameter);
         query.getResultList().forEach(r -> {
-            PantryItem item = toFetchById.get(r.id());
-            item.setUseCount(r.count());
+            T item = toFetchById.get(r.id());
+            setter.accept(item, r.count());
             result.put(item, r.count());
         });
         return result;
     }
 
     @Override
+    public Map<PantryItem, Long> countTotalUses(Collection<PantryItem> items) {
+        return countSomething(items,
+                              PantryItem::getUseCount,
+                              PantryItem::setUseCount,
+                              USE_COUNT_BY_ID);
+    }
+
+    @VisibleForTesting
+    Long countDuplicates(PantryItem item) {
+        return countDuplicates(Collections.singleton(item))
+                .get(item);
+    }
+
+    @Override
     public Map<PantryItem, Long> countDuplicates(Collection<PantryItem> items) {
-        return Map.of(); // todo: implement
+        return countSomething(items,
+                              PantryItem::getDuplicateCount,
+                              PantryItem::setDuplicateCount,
+                              DUPLICATE_COUNT_BY_ID);
     }
 
     @Override
     public SearchResponse<PantryItem> search(PantryItemSearchRequest request) {
-        // todo: consider request.duplicateOf
-        var sortedByUseCount = request.isSorted()
-                               && request.getSort()
-                                       .stream()
-                                       .anyMatch(s -> "useCount".equals(s.getProperty())
-                                                      || "useCounts".equals(s.getProperty()));
+        boolean sortedByUseCount = false;
+        boolean sortedByDuplicateCount = false;
+        if (request.isSorted()) {
+            for (var s : request.getSort()) {
+                switch (s.getProperty()) {
+                    case "useCount" -> sortedByUseCount = true;
+                    case "duplicateCount" -> sortedByDuplicateCount = true;
+                }
+            }
+        }
+        var sortedByACount = sortedByUseCount || sortedByDuplicateCount;
         var stmt = new NamedParameterQuery("select distinct item\n");
-        if (sortedByUseCount) {
+        if (sortedByACount) {
             stmt.append(String.format(
                     """
                          , %s as use_count
-                    """, String.format(USE_COUNT_BY_ID, "item.id")));
+                    """,
+                    sortedByUseCount ? String.format(USE_COUNT_BY_ID, "item.id") : -1));
+            stmt.append(String.format(
+                    """
+                         , %s as dupe_count
+                    """,
+                    sortedByDuplicateCount ? String.format(DUPLICATE_COUNT_BY_ID, "item.id") : -1));
         }
         stmt.append("""
                     from PantryItem item
@@ -102,7 +165,7 @@ public class PantryItemSearchRepositoryImpl implements PantryItemSearchRepositor
             for (var word : EnglishUtils.canonicalize(request.getFilter())
                     .split(" ")) {
                 if (word.isBlank()) continue;
-                stmt.append(i == 0 ? "where" : "or");
+                stmt.append(i == 0 ? "where (" : "or");
                 String p = "p" + (i++);
                 stmt.append(String.format(
                         """
@@ -111,13 +174,25 @@ public class PantryItemSearchRepositoryImpl implements PantryItemSearchRepositor
                          or upper(lbl.name) like upper('%%' || :%1$s || '%%') escape '\\')
                         """, p), p, word);
             }
+            stmt.append(")\n");
+        }
+        if (request.isDuplicateOf()) {
+            stmt.append(request.isFiltered() ? "and " : "where ")
+                    .append("""
+                            exists (from PantryItemDuplicate
+                                    where pantryItem.id = :dupeOf
+                                      and duplicate.id = item.id
+                                      and not loose
+                                   )
+                            """, "dupeOf", request.getDuplicateOf());
         }
         stmt.append("order by ");
         if (request.isSorted()) {
             for (var sort : request.getSort()) {
                 switch (sort.getProperty()) {
                     case "firstUse" -> stmt.identifier("item.createdAt");
-                    case "useCount", "useCounts" -> stmt.append("use_count");
+                    case "useCount" -> stmt.identifier("use_count");
+                    case "duplicateCount" -> stmt.identifier("dupe_count");
                     default -> stmt.identifier("item." + sort.getProperty());
                 }
                 stmt.append(" ")
@@ -127,12 +202,18 @@ public class PantryItemSearchRepositoryImpl implements PantryItemSearchRepositor
         }
         stmt.append("item.id");
         List<PantryItem> pantryItems;
-        if (sortedByUseCount) {
-            pantryItems = query(request, stmt, ItemAndUse.class)
+        if (sortedByACount) {
+            pantryItems = query(request, stmt, ItemAndCounts.class)
                     .stream()
-                    .map(iau -> {
-                        iau.item().setUseCount(iau.useCount());
-                        return iau.item();
+                    .map(iac -> {
+                        PantryItem item = iac.item();
+                        if (iac.useCount() instanceof Long c) {
+                            item.setUseCount(c);
+                        }
+                        if (iac.dupeCount() instanceof Long c) {
+                            item.setDuplicateCount(c);
+                        }
+                        return item;
                     })
                     .toList();
         } else {

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/SearchResponse.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/SearchResponse.java
@@ -12,7 +12,7 @@ public interface SearchResponse<R> {
 
     List<R> getContent();
 
-    default int getSize() {
+    default int size() {
         return getContent().size();
     }
 

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/impl/PantryItemSearchRequest.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/impl/PantryItemSearchRequest.java
@@ -1,5 +1,6 @@
 package com.brennaswitzer.cookbook.repositories.impl;
 
+import com.brennaswitzer.cookbook.domain.PantryItem_;
 import com.brennaswitzer.cookbook.repositories.SearchRequest;
 import lombok.Builder;
 import lombok.Value;
@@ -10,6 +11,7 @@ import org.springframework.data.domain.Sort;
 public class PantryItemSearchRequest implements SearchRequest {
 
     String filter;
+    Long duplicateOf;
     int offset;
     int limit;
     Sort sort;
@@ -17,4 +19,21 @@ public class PantryItemSearchRequest implements SearchRequest {
     public boolean isFiltered() {
         return filter != null && !filter.isBlank();
     }
+
+    public boolean isDuplicateOf() {
+        return duplicateOf != null;
+    }
+
+    public int getLimit() {
+        if (limit <= 0) return 10;
+        return limit;
+    }
+
+    public Sort getSort() {
+        if (sort == null) {
+            return Sort.by(PantryItem_.NAME);
+        }
+        return sort;
+    }
+
 }

--- a/src/main/java/com/brennaswitzer/cookbook/services/PantryItemService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/PantryItemService.java
@@ -67,7 +67,6 @@ public class PantryItemService {
     }
 
     @PreAuthorize("hasRole('DEVELOPER')")
-    @Transactional(readOnly = true) // GraphQL manages txns imperatively for OSIV
     public SearchResponse<PantryItem> search(String filter,
                                              Sort sort,
                                              int offset,
@@ -75,6 +74,20 @@ public class PantryItemService {
         return pantryItemRepository.search(
                 PantryItemSearchRequest.builder()
                         .filter(filter)
+                        .sort(sort)
+                        .offset(offset)
+                        .limit(limit)
+                        .build());
+    }
+
+    @PreAuthorize("hasRole('DEVELOPER')")
+    public SearchResponse<PantryItem> duplicatesOf(long itemId,
+                                                   Sort sort,
+                                                   int offset,
+                                                   int limit) {
+        return pantryItemRepository.search(
+                PantryItemSearchRequest.builder()
+                        .duplicateOf(itemId)
                         .sort(sort)
                         .offset(offset)
                         .limit(limit)

--- a/src/main/java/com/brennaswitzer/cookbook/services/PantryItemService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/PantryItemService.java
@@ -7,7 +7,6 @@ import com.brennaswitzer.cookbook.repositories.SearchResponse;
 import com.brennaswitzer.cookbook.repositories.impl.PantryItemSearchRequest;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Sort;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -67,31 +66,8 @@ public class PantryItemService {
     }
 
     @PreAuthorize("hasRole('DEVELOPER')")
-    public SearchResponse<PantryItem> search(String filter,
-                                             Sort sort,
-                                             int offset,
-                                             int limit) {
-        return pantryItemRepository.search(
-                PantryItemSearchRequest.builder()
-                        .filter(filter)
-                        .sort(sort)
-                        .offset(offset)
-                        .limit(limit)
-                        .build());
-    }
-
-    @PreAuthorize("hasRole('DEVELOPER')")
-    public SearchResponse<PantryItem> duplicatesOf(long itemId,
-                                                   Sort sort,
-                                                   int offset,
-                                                   int limit) {
-        return pantryItemRepository.search(
-                PantryItemSearchRequest.builder()
-                        .duplicateOf(itemId)
-                        .sort(sort)
-                        .offset(offset)
-                        .limit(limit)
-                        .build());
+    public SearchResponse<PantryItem> search(PantryItemSearchRequest request) {
+        return pantryItemRepository.search(request);
     }
 
     @PreAuthorize("hasRole('DEVELOPER')")

--- a/src/main/java/com/brennaswitzer/cookbook/services/async/QueueProcessor.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/async/QueueProcessor.java
@@ -1,4 +1,4 @@
-package com.brennaswitzer.cookbook.services.indexing;
+package com.brennaswitzer.cookbook.services.async;
 
 import com.brennaswitzer.cookbook.util.NamedParameterQuery;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/brennaswitzer/cookbook/services/indexing/EventHandlerSlot.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/indexing/EventHandlerSlot.java
@@ -1,0 +1,12 @@
+package com.brennaswitzer.cookbook.services.indexing;
+
+final class EventHandlerSlot {
+
+    // pretty please, keep these in numeric order
+    static final int REINDEX = 100;
+    static final int DUPLICATES = 500;
+
+    private EventHandlerSlot() {
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/services/indexing/IngredientNeedsReindexing.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/indexing/IngredientNeedsReindexing.java
@@ -1,0 +1,11 @@
+package com.brennaswitzer.cookbook.services.indexing;
+
+import com.brennaswitzer.cookbook.domain.Ingredient;
+
+public record IngredientNeedsReindexing(Ingredient ingredient) {
+
+    public Long id() {
+        return ingredient.getId();
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/services/indexing/IngredientReindexQueueService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/indexing/IngredientReindexQueueService.java
@@ -70,7 +70,7 @@ public class IngredientReindexQueueService {
                 "VALUES (:id)\n",
                 "id",
                 ingredient.getId()));
-        eventPublisher.publishEvent(new ReindexIngredientEvent(ingredient.getId()));
+        eventPublisher.publishEvent(new IngredientNeedsReindexing(ingredient));
     }
 
     public void enqueueRecipesWithIngredient(Ingredient ingredient) {

--- a/src/main/java/com/brennaswitzer/cookbook/services/indexing/PantryItemNeedsDuplicatesFound.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/indexing/PantryItemNeedsDuplicatesFound.java
@@ -1,0 +1,11 @@
+package com.brennaswitzer.cookbook.services.indexing;
+
+import com.brennaswitzer.cookbook.domain.PantryItem;
+
+public record PantryItemNeedsDuplicatesFound(PantryItem item) {
+
+    public Long id() {
+        return item.getId();
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/services/indexing/QueueProcessor.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/indexing/QueueProcessor.java
@@ -43,7 +43,7 @@ public abstract class QueueProcessor {
 
     protected abstract NamedParameterQuery selectAllIds();
 
-    protected final int drainQueue() {
+    public int drainQueue() {
         if (!lock.tryLock()) return 0;
         try {
             return drainQueueInternal();

--- a/src/main/java/com/brennaswitzer/cookbook/services/indexing/RefreshPantryItemDuplicates.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/indexing/RefreshPantryItemDuplicates.java
@@ -1,5 +1,6 @@
 package com.brennaswitzer.cookbook.services.indexing;
 
+import com.brennaswitzer.cookbook.services.async.QueueProcessor;
 import com.brennaswitzer.cookbook.util.NamedParameterQuery;
 import org.springframework.core.annotation.Order;
 import org.springframework.scheduling.annotation.Scheduled;

--- a/src/main/java/com/brennaswitzer/cookbook/services/indexing/RefreshPantryItemDuplicates.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/indexing/RefreshPantryItemDuplicates.java
@@ -1,14 +1,27 @@
 package com.brennaswitzer.cookbook.services.indexing;
 
 import com.brennaswitzer.cookbook.util.NamedParameterQuery;
+import org.springframework.core.annotation.Order;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Service
 public class RefreshPantryItemDuplicates extends QueueProcessor {
 
     protected RefreshPantryItemDuplicates() {
         super("q_pantry_item_duplicates", 1);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Order(EventHandlerSlot.DUPLICATES)
+    public void handleRefresh(PantryItemNeedsDuplicatesFound ignored) {
+        // This is COARSE, to say the least...
+        enqueueAll();
     }
 
     @Override

--- a/src/main/java/com/brennaswitzer/cookbook/services/indexing/ReindexIngredientEvent.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/indexing/ReindexIngredientEvent.java
@@ -1,3 +1,0 @@
-package com.brennaswitzer.cookbook.services.indexing;
-
-public record ReindexIngredientEvent(Long ingredientId) {}

--- a/src/main/java/com/brennaswitzer/cookbook/services/indexing/ReindexIngredients.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/indexing/ReindexIngredients.java
@@ -1,5 +1,6 @@
 package com.brennaswitzer.cookbook.services.indexing;
 
+import com.brennaswitzer.cookbook.services.async.QueueProcessor;
 import com.brennaswitzer.cookbook.util.NamedParameterQuery;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;

--- a/src/main/resources/graphqls/pantry.graphqls
+++ b/src/main/resources/graphqls/pantry.graphqls
@@ -30,7 +30,27 @@ type PantryQuery {
         """
         after: Cursor = null
     ): PantryItemConnection!
-
+    duplicates(
+        """Return auto-detected duplicates of the item with this ID. Exactly
+        what "duplicate" means is unspecified and subject to change, excepting
+        that it will remain consistent with results' "duplicateCount".
+        """
+        of: ID!
+        """Field to sort the result by. If omitted, the sort will be stable, but
+        is otherwise unspecified.
+        """
+        sortBy: String
+        """Direction to sort the result, ascending by default.
+        """
+        sortDir: SortDir = ASC
+        """How many items to return in the connection.
+        """
+        first: NonNegativeInt = 25
+        """Cursor to find results after. This should be omitted to retrieve the
+        first page.
+        """
+        after: Cursor = null
+    ): PantryItemConnection!
 }
 
 type PantryItemConnection {
@@ -62,6 +82,11 @@ type PantryItem implements Node & Ingredient {
     library recipes and on a plan.
     """
     useCount: NonNegativeInt!
+    """The number of auto-detected duplicates of this pantry item. Exactly what
+    "duplicate" means is unspecified and subject to change, excepting that it
+    will remain consistent with the "duplicateOf" search field.
+    """
+    duplicateCount: NonNegativeInt!
 }
 
 extend type Mutation {

--- a/src/main/resources/graphqls/pantry.graphqls
+++ b/src/main/resources/graphqls/pantry.graphqls
@@ -12,37 +12,12 @@ type PantryQuery {
     """
     search(
         """Textual query to filter items by. The exact query operation performed
-        is unspecified.
+        is unspecified, except that 'duplicates:12345' will return auto-detected
+        duplicates of the item with id '12345'. Exactly what "duplicate" means
+        is unspecified and subject to change, excepting that it will remain
+        consistent with results' "duplicateCount".
         """
         query: String
-        """ID of the item to retrieve auto-detected duplicates of. Exactly what
-        "duplicate" means is unspecified and subject to change, excepting that it
-        will remain consistent with results' "duplicateCount".
-        """
-        duplicateOf: ID
-        """Field to sort the result by. If omitted, the sort will be stable, but
-        is otherwise unspecified.
-        """
-        sortBy: String
-        """Direction to sort the result, ascending by default.
-        """
-        sortDir: SortDir = ASC
-        """How many items to return in the connection.
-        """
-        first: NonNegativeInt = 25
-        """Cursor to find results after. This should be omitted to retrieve the
-        first page.
-        """
-        after: Cursor = null
-    ): PantryItemConnection!
-    """Return auto-detected duplicates of a specific pantry item. Exactly what
-    "duplicate" means is unspecified and subject to change, excepting that it
-    will remain consistent with results' "duplicateCount".
-    """
-    duplicates(
-        """ID of the item to retrieve duplicates of.
-        """
-        of: ID!
         """Field to sort the result by. If omitted, the sort will be stable, but
         is otherwise unspecified.
         """
@@ -91,7 +66,7 @@ type PantryItem implements Node & Ingredient {
     useCount: NonNegativeInt!
     """The number of auto-detected duplicates of this pantry item. Exactly what
     "duplicate" means is unspecified and subject to change, excepting that it
-    will remain consistent with the "duplicateOf" search field.
+    will remain consistent with a 'duplicates:12345' search query.
     """
     duplicateCount: NonNegativeInt!
 }

--- a/src/main/resources/graphqls/pantry.graphqls
+++ b/src/main/resources/graphqls/pantry.graphqls
@@ -15,6 +15,11 @@ type PantryQuery {
         is unspecified.
         """
         query: String
+        """ID of the item to retrieve auto-detected duplicates of. Exactly what
+        "duplicate" means is unspecified and subject to change, excepting that it
+        will remain consistent with results' "duplicateCount".
+        """
+        duplicateOf: ID
         """Field to sort the result by. If omitted, the sort will be stable, but
         is otherwise unspecified.
         """
@@ -30,10 +35,12 @@ type PantryQuery {
         """
         after: Cursor = null
     ): PantryItemConnection!
+    """Return auto-detected duplicates of a specific pantry item. Exactly what
+    "duplicate" means is unspecified and subject to change, excepting that it
+    will remain consistent with results' "duplicateCount".
+    """
     duplicates(
-        """Return auto-detected duplicates of the item with this ID. Exactly
-        what "duplicate" means is unspecified and subject to change, excepting
-        that it will remain consistent with results' "duplicateCount".
+        """ID of the item to retrieve duplicates of.
         """
         of: ID!
         """Field to sort the result by. If omitted, the sort will be stable, but

--- a/src/test/java/com/brennaswitzer/cookbook/repositories/PantryItemSearchRepositoryImplTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/repositories/PantryItemSearchRepositoryImplTest.java
@@ -105,6 +105,21 @@ class PantryItemSearchRepositoryImplTest {
     }
 
     @Test
+    void sortByBothLazyCounts() {
+        SearchResponse<PantryItem> result = repo.search(
+                PantryItemSearchRequest.builder()
+                        .sort(Sort.by(Sort.Direction.DESC, "useCount", "duplicateCount"))
+                        .build());
+
+        PantryItem salt = extractItemByName(result, "salt");
+        // both count came through, since they _had_ to be retrieved
+        assertEquals(2, salt.getUseCount());
+        assertEquals(0, salt.getDuplicateCount());
+        assertEquals(2, repo.countTotalUses(salt));
+        assertEquals(0, repo.countDuplicates(salt));
+    }
+
+    @Test
     void filter() {
         SearchResponse<PantryItem> result = repo.search(
                 PantryItemSearchRequest.builder()

--- a/src/test/java/com/brennaswitzer/cookbook/repositories/RecipeSearchRepositoryImplTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/repositories/RecipeSearchRepositoryImplTest.java
@@ -83,7 +83,7 @@ public class RecipeSearchRepositoryImplTest {
                 .setMaxResults(2 + 1);
         assertFalse(result.isFirst());
         assertFalse(result.isLast());
-        assertEquals(2, result.getSize());
+        assertEquals(2, result.size());
     }
 
     @Test

--- a/src/test/java/com/brennaswitzer/cookbook/services/indexing/IngredientIndexSmokeTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/services/indexing/IngredientIndexSmokeTest.java
@@ -38,8 +38,8 @@ class IngredientIndexSmokeTest {
     @Test
     void oneShotReindex() {
         indexer.reindexIngredientImmediately(
-                new ReindexIngredientEvent(
-                        box.flour.getId()));
+                new IngredientNeedsReindexing(
+                        box.flour));
     }
 
     @Test

--- a/src/test/java/com/brennaswitzer/cookbook/services/indexing/IngredientReindexQueueServiceTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/services/indexing/IngredientReindexQueueServiceTest.java
@@ -62,7 +62,7 @@ class IngredientReindexQueueServiceTest {
         assertEquals(Map.of("id", id),
                      paramsCaptor.getValue());
         verify(eventPublisher)
-                .publishEvent(argThat((ReindexIngredientEvent e) -> id.equals(e.ingredientId())));
+                .publishEvent(argThat((IngredientNeedsReindexing e) -> id.equals(e.id())));
     }
 
     @Test

--- a/src/test/java/com/brennaswitzer/cookbook/util/RecipeBox.java
+++ b/src/test/java/com/brennaswitzer/cookbook/util/RecipeBox.java
@@ -17,6 +17,7 @@ public class RecipeBox {
             lbs;
 
     public final PantryItem
+            chicken,
             egg,
             flour,
             oil,
@@ -49,6 +50,7 @@ public class RecipeBox {
         dinner = new Label("dinner");
         makeAhead = new Label("make ahead");
 
+        chicken = new PantryItem("chicken");
         egg = new PantryItem("egg");
         flour = new PantryItem("flour")
                 .withLabel(bulk)
@@ -65,7 +67,7 @@ public class RecipeBox {
         friedChicken = new Recipe("Fried Chicken")
                 .withLabel(dinner);
         friedChicken.addIngredient(Quantity.count(2), egg, "shelled");
-        friedChicken.addIngredient(new PantryItem("chicken"), "deboned");
+        friedChicken.addIngredient(chicken, "deboned");
         friedChicken.addIngredient(new PantryItem("chicken thigh"), "cut");
 
         pizzaSauce = new Recipe("Pizza Sauce")


### PR DESCRIPTION
Expose duplicate pantry item info through the graphql interface, both counts and searching "duplicates of" an item. Right now, it's only 'tight' duplicates, meaning those which match full names/synonym, to reduce noise. So "cabbage" will consider "red cabbage" a duplicate, but not the converse.

Tracking of 'loose' duplicates, which do sub-matching, is in place but not exposed. When that's turned on "red cabbage" will consider both "cabbage" _and_ "red onion" as duplicates. All 'tight' duplicates are also 'loose' duplicates. From a Feb '23 dump of prod, there are about 2100 'tight' dupes, and another 6300 'loose' dupes. Note that those counts are bidirectional, so three identically-named items will express six dupes, and five such items will express twenty (`n * (n-1)`).