### PR TITLE
Cook planned stuff

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/domain/BaseEntity.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/BaseEntity.java
@@ -34,21 +34,18 @@ public abstract class BaseEntity implements Identified {
     private final Long _eqkey = IdUtils.next(getClass());
 
     @NotNull
-    @Column(name = "created_at")
     @Getter
     @Setter
     private Instant createdAt;
 
     @NotNull
     @Version
-    @Column(name = "updated_at")
     @Getter
     private Instant updatedAt;
 
     @PrePersist
     protected void onPrePersist() {
-        Instant now = Instant.now();
-        setCreatedAt(now);
+        setCreatedAt(Instant.now());
     }
 
     /**

--- a/src/main/java/com/brennaswitzer/cookbook/domain/InventoryItem.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/InventoryItem.java
@@ -39,8 +39,7 @@ public class InventoryItem extends BaseEntity {
     @OneToMany(
             orphanRemoval = true,
             mappedBy = "item",
-            cascade = { CascadeType.ALL },
-            fetch = FetchType.LAZY)
+            cascade = { CascadeType.ALL })
     @Getter
     private List<InventoryTx> transactions = new ArrayList<>();
 

--- a/src/main/java/com/brennaswitzer/cookbook/domain/PantryItemDuplicate.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/PantryItemDuplicate.java
@@ -18,11 +18,11 @@ public class PantryItemDuplicate {
 
     @Id
     @ManyToOne(fetch = FetchType.LAZY)
-    PantryItem pantryItem;
+    private PantryItem pantryItem;
     @Id
     @ManyToOne(fetch = FetchType.LAZY)
-    PantryItem duplicate;
-    boolean loose;
-    float matchRank;
+    private PantryItem duplicate;
+    private boolean loose;
+    private float matchRank;
 
 }

--- a/src/main/java/com/brennaswitzer/cookbook/domain/PlanItem.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/PlanItem.java
@@ -40,7 +40,7 @@ import static jakarta.persistence.CascadeType.REFRESH;
 @SuppressWarnings("WeakerAccess")
 @Entity
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
-@DiscriminatorColumn(name = "_type")
+@DiscriminatorColumn
 @DiscriminatorValue("item")
 public class PlanItem extends BaseEntity implements Named, MutableItem {
 

--- a/src/main/java/com/brennaswitzer/cookbook/domain/PlanItem.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/PlanItem.java
@@ -259,7 +259,9 @@ public class PlanItem extends BaseEntity implements Named, MutableItem {
     public void moveToTrash() {
         this.trashBin = getPlan();
         this.trashBin.getTrashBinItems().add(this);
-        this.status = PlanItemStatus.DELETED;
+        if (!this.status.isForDelete()) {
+            this.status = PlanItemStatus.DELETED;
+        }
         getParent().markDirty();
     }
 

--- a/src/main/java/com/brennaswitzer/cookbook/domain/PlanItemStatus.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/PlanItemStatus.java
@@ -7,16 +7,19 @@ public enum PlanItemStatus implements Identified {
 
     NEEDED(0L),
     ACQUIRED(50L),
-    COMPLETED(100L),
-    DELETED(-1L);
+    COMPLETED(100L, true),
+    DELETED(-1L, true);
 
     private final Long id;
+    private final boolean forDelete;
 
     PlanItemStatus(Long id) {
-        this.id = id;
+        this(id, false);
     }
 
-    public boolean isForDelete() {
-        return COMPLETED.equals(this) || DELETED.equals(this);
+    PlanItemStatus(Long id, boolean forDelete) {
+        this.id = id;
+        this.forDelete = forDelete;
     }
+
 }

--- a/src/main/java/com/brennaswitzer/cookbook/domain/PlannedRecipeHistory.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/PlannedRecipeHistory.java
@@ -1,0 +1,38 @@
+package com.brennaswitzer.cookbook.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Setter
+@Getter
+@Entity
+public class PlannedRecipeHistory extends BaseEntity {
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Recipe recipe;
+
+    /**
+     * The ID of the plan item this recipe was planned as.
+     */
+    @NotNull
+    @Column(updatable = false)
+    private Long planItemId;
+
+    @NotNull
+    @Column(updatable = false)
+    private Instant plannedAt;
+
+    @NotNull
+    @Column(name = "status_id",
+            updatable = false)
+    private PlanItemStatus status;
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/domain/Recipe.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/Recipe.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
@@ -93,23 +94,21 @@ public class Recipe extends Ingredient implements AggregateIngredient, Owned {
     @Setter
     private Integer totalTime;
 
+    @Setter
+    @Getter
     @ElementCollection
     @OrderBy("_idx, raw")
     private List<IngredientRef> ingredients;
+
+    @Getter
+    @OneToMany(mappedBy = "recipe")
+    private Collection<PlannedRecipeHistory> planHistory;
 
     public Recipe() {
     }
 
     public Recipe(String name) {
         setName(name);
-    }
-
-    public List<IngredientRef> getIngredients() {
-        return this.ingredients;
-    }
-
-    public void setIngredients(List<IngredientRef> ingredients) {
-        this.ingredients = ingredients;
     }
 
     @Override

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/PlannedRecipeHistoryRepository.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/PlannedRecipeHistoryRepository.java
@@ -1,0 +1,6 @@
+package com.brennaswitzer.cookbook.repositories;
+
+import com.brennaswitzer.cookbook.domain.PlannedRecipeHistory;
+
+public interface PlannedRecipeHistoryRepository extends BaseEntityRepository<PlannedRecipeHistory> {
+}

--- a/src/main/java/com/brennaswitzer/cookbook/services/EmptyTrashBins.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/EmptyTrashBins.java
@@ -21,7 +21,7 @@ public class EmptyTrashBins {
 
     @Scheduled(cron = "${random.int[60]} ${random.int[60]} * * * *")
     public void emptyTrashBins() {
-        val cutoff = Instant.now().minus(1, ChronoUnit.DAYS);
+        val cutoff = Instant.now().minus(7, ChronoUnit.DAYS);
         val n = planItemRepository.deleteByUpdatedAtBeforeAndTrashBinIsNotNull(cutoff);
         log.info("Deleted {} old item(s) from the trash bin", n);
     }

--- a/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
@@ -2,11 +2,13 @@ package com.brennaswitzer.cookbook.services;
 
 import com.brennaswitzer.cookbook.domain.AccessLevel;
 import com.brennaswitzer.cookbook.domain.AggregateIngredient;
+import com.brennaswitzer.cookbook.domain.Ingredient;
 import com.brennaswitzer.cookbook.domain.IngredientRef;
 import com.brennaswitzer.cookbook.domain.Plan;
 import com.brennaswitzer.cookbook.domain.PlanBucket;
 import com.brennaswitzer.cookbook.domain.PlanItem;
 import com.brennaswitzer.cookbook.domain.PlanItemStatus;
+import com.brennaswitzer.cookbook.domain.PlannedRecipeHistory;
 import com.brennaswitzer.cookbook.domain.Recipe;
 import com.brennaswitzer.cookbook.domain.User;
 import com.brennaswitzer.cookbook.message.MutatePlanTree;
@@ -16,9 +18,11 @@ import com.brennaswitzer.cookbook.payload.PlanItemInfo;
 import com.brennaswitzer.cookbook.repositories.PlanBucketRepository;
 import com.brennaswitzer.cookbook.repositories.PlanItemRepository;
 import com.brennaswitzer.cookbook.repositories.PlanRepository;
+import com.brennaswitzer.cookbook.repositories.PlannedRecipeHistoryRepository;
 import com.brennaswitzer.cookbook.repositories.UserRepository;
 import com.brennaswitzer.cookbook.util.UserPrincipalAccess;
 import lombok.val;
+import org.hibernate.Hibernate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,6 +48,9 @@ public class PlanService {
 
     @Autowired
     protected PlanBucketRepository bucketRepo;
+
+    @Autowired
+    private PlannedRecipeHistoryRepository recipeHistoryRepo;
 
     @Autowired
     protected UserPrincipalAccess principalAccess;
@@ -365,41 +372,51 @@ public class PlanService {
 
     public PlanItem setItemStatus(Long id, PlanItemStatus status) {
         PlanItem item = getPlanItemById(id, AccessLevel.CHANGE);
-        if (status.isForDelete()) {
+        item.setStatus(status);
+        if (item.getStatus().isForDelete()) {
+            recordRecipeHistories(item, item.getStatus());
             item.moveToTrash();
         }
-        item.setStatus(status);
         return item;
     }
 
-    public PlanMessage setItemStatusForMessage(Long id, PlanItemStatus status) {
-        if (status.isForDelete()) {
-            return deleteItemForMessage(id);
+    private void recordRecipeHistories(PlanItem item,
+                                       PlanItemStatus status) {
+        Ingredient ingredient = (Ingredient) Hibernate.unproxy(item.getIngredient());
+        if (ingredient instanceof Recipe r) {
+            var h = new PlannedRecipeHistory();
+            h.setRecipe(r);
+            h.setPlanItemId(item.getId());
+            h.setPlannedAt(item.getCreatedAt());
+            h.setStatus(status);
+            recipeHistoryRepo.save(h);
         }
-        PlanItem item = getPlanItemById(id, AccessLevel.CHANGE);
-        item.setStatus(status);
+        if (item.hasChildren()) {
+            item.getChildView()
+                    .forEach(it -> recordRecipeHistories(it, status));
+        }
+    }
+
+    public PlanMessage setItemStatusForMessage(Long id, PlanItemStatus status) {
+        PlanItem item = setItemStatus(id, status);
+        if (item.getStatus().isForDelete()) {
+            val m = new PlanMessage();
+            m.setId(id);
+            m.setType("delete");
+            return m;
+        }
         return buildUpdateMessage(item);
     }
 
     public PlanItem deleteItemForParent(Long id) {
-        val item = getPlanItemById(id, AccessLevel.CHANGE);
+        val item = setItemStatus(id, PlanItemStatus.DELETED);
         if (item.hasParent()) {
-            val parent = item.getParent();
-            item.moveToTrash();
-            return parent;
+            return item.getParent();
         } else {
             throw new IllegalArgumentException(String.format(
                     "ID '%s' is a plan",
                     id));
         }
-    }
-
-    public PlanMessage deleteItemForMessage(Long id) {
-        deleteItemForParent(id);
-        val m = new PlanMessage();
-        m.setId(id);
-        m.setType("delete");
-        return m;
     }
 
     public void deletePlan(Long id) {

--- a/src/main/resources/db/changelog/gobrennas-2024.sql
+++ b/src/main/resources/db/changelog/gobrennas-2024.sql
@@ -379,3 +379,24 @@ ON CONFLICT DO NOTHING;
 --changeset barneyb:use-dtype-for-plan-items-discriminator
 alter table plan_item
     rename column _type to dtype;
+
+--changeset barneyb:planned-recipe-history
+create table planned_recipe_history
+(
+    id           bigint                   not null default nextval('id_seq'),
+    _eqkey       bigint                   not null default date_part('epoch'::text, clock_timestamp()),
+    created_at   timestamp with time zone not null,
+    updated_at   timestamp with time zone not null,
+    recipe_id    bigint                   not null,
+    plan_item_id bigint                   not null,
+    planned_at   timestamp with time zone not null,
+    status_id    bigint                   not null,
+    constraint pk_planned_recipe_history primary key (id),
+    constraint fk_planned_recipe_history_recipe
+        foreign key (recipe_id)
+            references ingredient (id)
+            on delete cascade
+);
+
+create index idx_planned_recipe_history_recipe
+    on planned_recipe_history (recipe_id);

--- a/src/main/resources/db/changelog/gobrennas-2024.sql
+++ b/src/main/resources/db/changelog/gobrennas-2024.sql
@@ -375,3 +375,7 @@ SELECT id
 FROM ingredient
 WHERE dtype = 'PantryItem'
 ON CONFLICT DO NOTHING;
+
+--changeset barneyb:use-dtype-for-plan-items-discriminator
+alter table plan_item
+    rename column _type to dtype;

--- a/src/test/java/com/brennaswitzer/cookbook/services/PlanServiceTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/services/PlanServiceTest.java
@@ -4,10 +4,14 @@ import com.brennaswitzer.cookbook.domain.AccessLevel;
 import com.brennaswitzer.cookbook.domain.Plan;
 import com.brennaswitzer.cookbook.domain.PlanItem;
 import com.brennaswitzer.cookbook.domain.PlanItemStatus;
+import com.brennaswitzer.cookbook.domain.PlannedRecipeHistory;
 import com.brennaswitzer.cookbook.domain.User;
 import com.brennaswitzer.cookbook.repositories.PlanItemRepository;
 import com.brennaswitzer.cookbook.repositories.PlanRepository;
+import com.brennaswitzer.cookbook.repositories.PlannedRecipeHistoryRepository;
 import com.brennaswitzer.cookbook.repositories.UserRepository;
+import com.brennaswitzer.cookbook.util.RecipeBox;
+import com.brennaswitzer.cookbook.util.UserPrincipalAccess;
 import com.brennaswitzer.cookbook.util.WithAliceBobEve;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +19,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Iterator;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -36,7 +42,13 @@ class PlanServiceTest {
     private PlanRepository planRepo;
 
     @Autowired
+    private PlannedRecipeHistoryRepository recipeHistoryRepo;
+
+    @Autowired
     private EntityManager entityManager;
+
+    @Autowired
+    UserPrincipalAccess principalAccess;
 
     @Autowired
     private UserRepository userRepo;
@@ -152,6 +164,60 @@ class PlanServiceTest {
         entityManager.clear();
 
         assertEquals(0, itemRepo.count());
+    }
+
+    @Test
+    void statusChangeEvents() {
+        assert 0 == recipeHistoryRepo.count(); // sanity
+        var box = new RecipeBox();
+        box.persist(entityManager, principalAccess.getUser());
+        Plan groceries = service.createPlan("This Week", alice);
+        service.addRecipe(groceries.getId(), box.pizza, 1.0);
+        entityManager.flush();
+        PlanItem pizza = groceries.getChildView().iterator().next();
+        PlanItem sauce = null, crust = null;
+        for (var it : pizza.getChildView()) {
+            if (box.pizzaSauce.equals(it.getIngredient())) {
+                sauce = it;
+                // mark tomatoes acquired
+                service.setItemStatusForMessage(it.getChildView().iterator().next().getId(),
+                                                PlanItemStatus.ACQUIRED);
+                entityManager.flush();
+            } else if (box.pizzaCrust.equals(it.getIngredient())) {
+                crust = it;
+                // delete crust
+                service.deleteItemForParent(it.getId());
+                entityManager.flush();
+            }
+        }
+        assert sauce != null;
+        assert crust != null;
+        // mark pizza (and implicitly, sauce) completed
+        service.setItemStatus(pizza.getId(),
+                              PlanItemStatus.COMPLETED);
+        entityManager.flush();
+
+        var byRecipe = recipeHistoryRepo.findAll()
+                .stream()
+                .collect(Collectors.toMap(PlannedRecipeHistory::getRecipe,
+                                          Function.identity()));
+        // crust got deleted
+        var h = byRecipe.get(box.pizzaCrust);
+        assertEquals(crust.getId(), h.getPlanItemId());
+        assertNotNull(h.getPlannedAt());
+        assertEquals(PlanItemStatus.DELETED, h.getStatus());
+        // pizza got completed
+        h = byRecipe.get(box.pizza);
+        assertEquals(pizza.getId(), h.getPlanItemId());
+        assertNotNull(h.getPlannedAt());
+        assertEquals(PlanItemStatus.COMPLETED, h.getStatus());
+        // sauce got (implicitly) completed
+        h = byRecipe.get(box.pizzaSauce);
+        assertEquals(sauce.getId(), h.getPlanItemId());
+        assertNotNull(h.getPlannedAt());
+        assertEquals(PlanItemStatus.COMPLETED, h.getStatus());
+        // ignore tomatoes - not a recipe
+        assertEquals(3, recipeHistoryRepo.count());
     }
 
 }


### PR DESCRIPTION
When a recipe is removed from a plan, record its add/remove timestamps and final status in a new `PlannedRecipeHistory` entity, instances of which are owned by the recipe itself.