### PR TITLE
Planned recipe history

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/domain/Plan.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/Plan.java
@@ -24,11 +24,11 @@ public class Plan extends PlanItem implements AccessControlled {
     private Acl acl = new Acl();
 
     @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
-    @BatchSize(size = 100)
+    @BatchSize(size = 50)
     private Set<PlanBucket> buckets;
 
     @OneToMany(mappedBy = "trashBin", cascade = CascadeType.ALL)
-    @BatchSize(size = 100)
+    @BatchSize(size = 50)
     private Set<PlanItem> trashBinItems;
 
     public Plan() {

--- a/src/main/java/com/brennaswitzer/cookbook/domain/PlanItem.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/PlanItem.java
@@ -104,7 +104,7 @@ public class PlanItem extends BaseEntity implements Named, MutableItem {
     @OneToMany(
             mappedBy = "parent",
             cascade = ALL)
-    @BatchSize(size = 100)
+    @BatchSize(size = 50)
     private Set<PlanItem> children;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -117,7 +117,7 @@ public class PlanItem extends BaseEntity implements Named, MutableItem {
     @OneToMany(
             mappedBy = "aggregate",
             cascade = { PERSIST, MERGE, REFRESH, DETACH })
-    @BatchSize(size = 100)
+    @BatchSize(size = 50)
     private Set<PlanItem> components;
 
     @ManyToOne(

--- a/src/main/java/com/brennaswitzer/cookbook/domain/PlannedRecipeHistory.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/PlannedRecipeHistory.java
@@ -54,4 +54,8 @@ public class PlannedRecipeHistory extends BaseEntity implements Owned {
 
     private String notes;
 
+    public boolean isRated() {
+        return rating != null;
+    }
+
 }

--- a/src/main/java/com/brennaswitzer/cookbook/domain/PlannedRecipeHistory.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/PlannedRecipeHistory.java
@@ -9,11 +9,18 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.Instant;
+import java.util.Comparator;
 
 @Setter
 @Getter
 @Entity
 public class PlannedRecipeHistory extends BaseEntity {
+
+    public static final Comparator<PlannedRecipeHistory> BY_RECENT = (a, b) -> {
+        if (a == null) return b == null ? 0 : 1;
+        if (b == null) return -1;
+        return b.getDoneAt().compareTo(a.getDoneAt());
+    };
 
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
@@ -34,5 +41,9 @@ public class PlannedRecipeHistory extends BaseEntity {
     @Column(name = "status_id",
             updatable = false)
     private PlanItemStatus status;
+
+    public Instant getDoneAt() {
+        return getCreatedAt();
+    }
 
 }

--- a/src/main/java/com/brennaswitzer/cookbook/domain/PlannedRecipeHistory.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/PlannedRecipeHistory.java
@@ -14,7 +14,7 @@ import java.util.Comparator;
 @Setter
 @Getter
 @Entity
-public class PlannedRecipeHistory extends BaseEntity {
+public class PlannedRecipeHistory extends BaseEntity implements Owned {
 
     public static final Comparator<PlannedRecipeHistory> BY_RECENT = (a, b) -> {
         if (a == null) return b == null ? 0 : 1;
@@ -25,6 +25,10 @@ public class PlannedRecipeHistory extends BaseEntity {
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
     private Recipe recipe;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User owner;
 
     /**
      * The ID of the plan item this recipe was planned as.
@@ -38,12 +42,16 @@ public class PlannedRecipeHistory extends BaseEntity {
     private Instant plannedAt;
 
     @NotNull
+    @Column(updatable = false)
+    private Instant doneAt;
+
+    @NotNull
     @Column(name = "status_id",
             updatable = false)
     private PlanItemStatus status;
 
-    public Instant getDoneAt() {
-        return getCreatedAt();
-    }
+    private Rating rating;
+
+    private String notes;
 
 }

--- a/src/main/java/com/brennaswitzer/cookbook/domain/Rating.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/Rating.java
@@ -1,0 +1,17 @@
+package com.brennaswitzer.cookbook.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Rating implements Identified {
+    // Semantics and ids MUST NOT drift apart
+    ONE_STAR(1L),
+    TWO_STARS(2L),
+    THREE_STARS(3L),
+    FOUR_STARS(4L),
+    FIVE_STARS(5L);
+
+    private final Long id;
+}

--- a/src/main/java/com/brennaswitzer/cookbook/domain/Recipe.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/Recipe.java
@@ -17,6 +17,7 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -102,6 +103,7 @@ public class Recipe extends Ingredient implements AggregateIngredient, Owned {
 
     @Getter
     @OneToMany(mappedBy = "recipe")
+    @BatchSize(size = 50)
     private Collection<PlannedRecipeHistory> planHistory;
 
     public Recipe() {

--- a/src/main/java/com/brennaswitzer/cookbook/domain/Recipe.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/Recipe.java
@@ -29,13 +29,13 @@ import java.util.List;
 public class Recipe extends Ingredient implements AggregateIngredient, Owned {
 
     // this will gracefully store the same way as an @Embedded Acl will
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     private User owner;
 
     // these will gracefully emulate AccessControlled's owner property
     @JsonIgnore // but hide it from the client :)
     public User getOwner() { return owner; }
-    public void setOwner(User owner) { this.owner = owner; }
 
     // end access control emulation
 

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/resolvers/PlannedRecipeHistoryResolver.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/resolvers/PlannedRecipeHistoryResolver.java
@@ -1,0 +1,32 @@
+package com.brennaswitzer.cookbook.graphql.resolvers;
+
+import com.brennaswitzer.cookbook.domain.PlannedRecipeHistory;
+import graphql.kickstart.tools.GraphQLResolver;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+@Component
+public class PlannedRecipeHistoryResolver implements GraphQLResolver<PlannedRecipeHistory> {
+
+    public LocalDate plannedDate(PlannedRecipeHistory history) {
+        return plannedAt(history).toLocalDate();
+    }
+
+    public OffsetDateTime plannedAt(PlannedRecipeHistory history) {
+        return history.getPlannedAt()
+                .atOffset(ZoneOffset.UTC);
+    }
+
+    public LocalDate doneDate(PlannedRecipeHistory history) {
+        return doneAt(history).toLocalDate();
+    }
+
+    public OffsetDateTime doneAt(PlannedRecipeHistory history) {
+        return history.getDoneAt()
+                .atOffset(ZoneOffset.UTC);
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/resolvers/PlannedRecipeHistoryResolver.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/resolvers/PlannedRecipeHistoryResolver.java
@@ -29,4 +29,10 @@ public class PlannedRecipeHistoryResolver implements GraphQLResolver<PlannedReci
                 .atOffset(ZoneOffset.UTC);
     }
 
+    public Long ratingInt(PlannedRecipeHistory history) {
+        return history.isRated()
+                ? history.getRating().getId()
+                : null;
+    }
+
 }

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/RatingConverter.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/RatingConverter.java
@@ -1,0 +1,14 @@
+package com.brennaswitzer.cookbook.repositories;
+
+import com.brennaswitzer.cookbook.domain.Rating;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class RatingConverter extends AbstractIdentifiedEnumAttributeConverter<Rating> implements AttributeConverter<Rating, Long> {
+
+    public RatingConverter() {
+        super(Rating.class);
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
@@ -402,8 +402,10 @@ public class PlanService {
         if (ingredient instanceof Recipe r) {
             var h = new PlannedRecipeHistory();
             h.setRecipe(r);
+            h.setOwner(principalAccess.getUser());
             h.setPlanItemId(item.getId());
             h.setPlannedAt(item.getCreatedAt());
+            h.setDoneAt(Instant.now());
             h.setStatus(status);
             recipeHistoryRepo.save(h);
         }

--- a/src/main/resources/graphqls/library.graphqls
+++ b/src/main/resources/graphqls/library.graphqls
@@ -136,9 +136,25 @@ type Recipe implements Node & Owned & Ingredient {
     labels: [String!]
     yield: Int
     calories: Int
-    totalTime(unit: ChronoUnit = MINUTES): Int
+    totalTime(
+        unit: ChronoUnit = MINUTES
+    ): Int
     photo: Photo
     favorite: Boolean!
+    """Number of times this recipe has been sent to any plan, optionally
+    filtered by the result status (only COMPLETED and DELETED make sense).
+    """
+    plannedCount(
+        status: PlanItemStatus = null
+    ): Int!
+    """History of this recipe being planned, in reverse-chronological order,
+    optionally filtered by the result status (only COMPLETED and DELETED make
+    sense). By default, only the five most recent records will be returned.
+    """
+    plannedHistory(
+        status: PlanItemStatus = null,
+        last: NonNegativeInt = 5
+    ): [PlannedRecipeHistory!]!
 }
 
 type Photo {
@@ -161,6 +177,16 @@ type Quantity {
 type UnitOfMeasure implements Node {
     id: ID!
     name: String!
+}
+
+type PlannedRecipeHistory implements Node {
+    id: ID!
+    status: PlanItemStatus!
+    plannedAt: DateTime!
+    plannedDate: Date!
+    doneAt: DateTime!
+    doneDate: Date!
+    recipe: Recipe!
 }
 
 extend type Mutation {

--- a/src/main/resources/graphqls/library.graphqls
+++ b/src/main/resources/graphqls/library.graphqls
@@ -178,15 +178,31 @@ type UnitOfMeasure implements Node {
     id: ID!
     name: String!
 }
+enum Rating {
+    ONE_STAR
+    TWO_STARS
+    THREE_STARS
+    FOUR_STARS
+    FIVE_STARS
+}
 
 type PlannedRecipeHistory implements Node {
     id: ID!
+    """The recipe this history item is for.
+    """
+    recipe: Recipe!
+    """The user who owns this history item, which may or may not be the recipe's
+    owner.
+    """
+    owner: User!
     status: PlanItemStatus!
     plannedAt: DateTime!
     plannedDate: Date!
     doneAt: DateTime!
     doneDate: Date!
-    recipe: Recipe!
+    rating: Rating
+    ratingInt: PositiveInt
+    notes: String
 }
 
 extend type Mutation {

--- a/src/test/java/com/brennaswitzer/cookbook/services/PlanServiceTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/services/PlanServiceTest.java
@@ -240,7 +240,9 @@ class PlanServiceTest {
         // crust got deleted
         var h = byRecipe.get(box.pizzaCrust);
         assertEquals(crust.getId(), h.getPlanItemId());
+        assertEquals(alice, h.getOwner());
         assertNotNull(h.getPlannedAt());
+        assertNotNull(h.getDoneAt());
         assertEquals(PlanItemStatus.DELETED, h.getStatus());
         // pizza got completed
         h = byRecipe.get(box.pizza);


### PR DESCRIPTION
Offer planner history for recipes via graphql. Currently all in-memory processing, which should be fine for a while. In a couple years we'll need to revisit, as The Standard will have a few hundred items, and that's silly to pull into memory just to sort it and keep five.