### PR TITLE
put the right content type on the iCalendar plan

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/web/SharedPlanController.java
+++ b/src/main/java/com/brennaswitzer/cookbook/web/SharedPlanController.java
@@ -4,8 +4,10 @@ import com.brennaswitzer.cookbook.config.CalendarProperties;
 import com.brennaswitzer.cookbook.domain.Plan;
 import com.brennaswitzer.cookbook.services.PlanCalendar;
 import com.brennaswitzer.cookbook.util.ShareHelper;
+import jakarta.servlet.http.HttpServletResponse;
 import net.fortuna.ical4j.data.CalendarOutputter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.access.AuthorizationServiceException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,7 +15,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
-import java.io.Writer;
 
 @RestController
 @RequestMapping({ "/shared/plan" })
@@ -29,18 +30,19 @@ public class SharedPlanController {
     private PlanCalendar planCalendar;
 
     @GetMapping(
-            value = "/{slug}/{secret}/{id}.ics",
-            produces = "text/calendar")
+            value = "/{slug}/{secret}/{id}.ics")
     public void getPlanCalendar(
             @PathVariable("secret") String secret,
             @PathVariable("id") Long id,
-            Writer out) throws IOException {
+            HttpServletResponse response) throws IOException {
         if (!helper.isSecretValid(Plan.class, id, secret)) {
             throw new AuthorizationServiceException("Bad secret");
         }
+        response.setCharacterEncoding("UTF-8");
+        response.addHeader(HttpHeaders.CONTENT_TYPE, "text/calendar");
         new CalendarOutputter(calendarProperties.isValidate())
                 .output(planCalendar.getCalendar(id),
-                        out);
+                        response.getWriter());
     }
 
 }


### PR DESCRIPTION
curl now says `Content-Type: text/calendar; charset=UTF-8` is coming out of boot. Hopefully cloud run won't mess with it. :/