### PR TITLE
batch-load favorites for library search

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/domain/User.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/User.java
@@ -47,4 +47,8 @@ public class User extends BaseEntity {
     public String toString() {
         return super.toString() + "(" + email + ")";
     }
+
+    public boolean isOwnerOf(Owned owned) {
+        return equals(owned.getOwner());
+    }
 }

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/loaders/RecipeIsFavoriteBatchLoader.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/loaders/RecipeIsFavoriteBatchLoader.java
@@ -1,0 +1,61 @@
+package com.brennaswitzer.cookbook.graphql.loaders;
+
+import com.brennaswitzer.cookbook.domain.FavoriteType;
+import com.brennaswitzer.cookbook.domain.Recipe;
+import com.brennaswitzer.cookbook.domain.User;
+import com.brennaswitzer.cookbook.repositories.FavoriteRepository;
+import com.brennaswitzer.cookbook.util.UserPrincipalAccess;
+import com.google.common.annotations.VisibleForTesting;
+import org.dataloader.BatchLoader;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+@Component
+public class RecipeIsFavoriteBatchLoader implements BatchLoader<Recipe, Boolean> {
+
+    @Autowired
+    private FavoriteRepository repo;
+
+    @Autowired
+    private UserPrincipalAccess principalAccess;
+
+    @Override
+    public CompletionStage<List<Boolean>> load(List<Recipe> recipes) {
+        // Graphql will complete the future on a thread from its own pool,
+        // outside Spring's context, so retrieve the owner synchronously.
+        User owner = principalAccess.getUser();
+        return CompletableFuture.supplyAsync(() -> loadInternal(owner, recipes));
+    }
+
+    @VisibleForTesting
+    List<Boolean> loadInternal(User owner, List<Recipe> recipes) {
+        List<Long> ownedRecipeIds = recipes.stream()
+                .filter(owner::isOwnerOf)
+                .map(Recipe::getId)
+                .toList();
+        Set<Long> favoriteIds;
+        if (ownedRecipeIds.isEmpty()) {
+            favoriteIds = Collections.emptySet();
+        } else {
+            favoriteIds = new HashSet<>();
+            for (var f : repo.findByOwnerAndObjectTypeAndObjectIdIn(
+                    owner,
+                    FavoriteType.RECIPE.getKey(),
+                    ownedRecipeIds)) {
+                favoriteIds.add(f.getObjectId());
+            }
+        }
+        return recipes.stream()
+                .map(Recipe::getId)
+                .map(favoriteIds::contains)
+                .toList();
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/resolvers/RecipeResolver.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/resolvers/RecipeResolver.java
@@ -1,14 +1,15 @@
 package com.brennaswitzer.cookbook.graphql.resolvers;
 
-import com.brennaswitzer.cookbook.domain.FavoriteType;
 import com.brennaswitzer.cookbook.domain.IngredientRef;
 import com.brennaswitzer.cookbook.domain.Photo;
 import com.brennaswitzer.cookbook.domain.PlanItemStatus;
 import com.brennaswitzer.cookbook.domain.PlannedRecipeHistory;
 import com.brennaswitzer.cookbook.domain.Recipe;
+import com.brennaswitzer.cookbook.graphql.loaders.RecipeIsFavoriteBatchLoader;
 import com.brennaswitzer.cookbook.mapper.LabelMapper;
 import com.brennaswitzer.cookbook.services.favorites.FetchFavorites;
 import graphql.kickstart.tools.GraphQLResolver;
+import graphql.schema.DataFetchingEnvironment;
 import org.hibernate.Hibernate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -20,6 +21,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
 import static java.util.stream.Collectors.toList;
@@ -49,11 +51,10 @@ public class RecipeResolver implements GraphQLResolver<Recipe> {
                 .collect(toList());
     }
 
-    public boolean favorite(Recipe recipe) {
-        return fetchFavorites.byObject(
-                        FavoriteType.RECIPE.getKey(),
-                        recipe.getId())
-                .isPresent();
+    public CompletableFuture<Boolean> favorite(Recipe recipe,
+                                               DataFetchingEnvironment env) {
+        return env.<Recipe, Boolean>getDataLoader(RecipeIsFavoriteBatchLoader.class.getName())
+                .load(recipe);
     }
 
     public Photo photo(Recipe recipe) {

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/FavoriteRepository.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/FavoriteRepository.java
@@ -4,6 +4,7 @@ import com.brennaswitzer.cookbook.domain.Favorite;
 import com.brennaswitzer.cookbook.domain.User;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,6 +19,10 @@ public interface FavoriteRepository extends BaseEntityRepository<Favorite> {
     Optional<Favorite> findByOwnerAndObjectTypeAndObjectId(User owner,
                                                            String objectType,
                                                            Long objectId);
+
+    Iterable<Favorite> findByOwnerAndObjectTypeAndObjectIdIn(User owner,
+                                                             String objectType,
+                                                             Collection<Long> objectIds);
 
     int deleteByOwnerAndObjectTypeAndObjectId(User owner,
                                               String objectType,

--- a/src/main/java/com/brennaswitzer/cookbook/services/favorites/FetchFavorites.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/favorites/FetchFavorites.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,6 +34,12 @@ public class FetchFavorites {
         return repo.findByOwnerAndObjectTypeAndObjectId(principalAccess.getUser(),
                                                         objectType,
                                                         objectId);
+    }
+
+    public Iterable<Favorite> byObjects(String objectType, Collection<Long> objectIds) {
+        return repo.findByOwnerAndObjectTypeAndObjectIdIn(principalAccess.getUser(),
+                                                          objectType,
+                                                          objectIds);
     }
 
 }

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/loaders/RecipeIsFavoriteBatchLoaderTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/loaders/RecipeIsFavoriteBatchLoaderTest.java
@@ -1,0 +1,73 @@
+package com.brennaswitzer.cookbook.graphql.loaders;
+
+import com.brennaswitzer.cookbook.domain.Favorite;
+import com.brennaswitzer.cookbook.domain.FavoriteType;
+import com.brennaswitzer.cookbook.domain.Recipe;
+import com.brennaswitzer.cookbook.domain.User;
+import com.brennaswitzer.cookbook.repositories.FavoriteRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RecipeIsFavoriteBatchLoaderTest {
+
+    @InjectMocks
+    private RecipeIsFavoriteBatchLoader loader;
+
+    @Mock
+    private FavoriteRepository repo;
+
+    @Test
+    void happyPath() {
+        User owner = mock(User.class);
+        when(owner.isOwnerOf(any())).thenReturn(true, true, false);
+        Recipe one = mockRecipe(1L); // owned, but not fav
+        Recipe two = mockRecipe(2L); // owned and fav
+        Recipe three = mockRecipe(3L); // not owned
+        Favorite favTwo = mock(Favorite.class);
+        when(favTwo.getObjectId()).thenReturn(2L);
+        when(repo.findByOwnerAndObjectTypeAndObjectIdIn(any(), any(), any()))
+                .thenReturn(List.of(favTwo));
+
+        List<Boolean> result = loader.loadInternal(owner,
+                                                   List.of(one, two, three));
+
+        assertEquals(List.of(false, true, false), result);
+        verify(repo).findByOwnerAndObjectTypeAndObjectIdIn(
+                owner,
+                FavoriteType.RECIPE.getKey(),
+                List.of(1L, 2L));
+    }
+
+    @Test
+    void noOwnedRecipes() {
+        User owner = mock(User.class);
+        when(owner.isOwnerOf(any())).thenReturn(false);
+
+        List<Boolean> result = loader.loadInternal(owner,
+                                                   List.of(mock(Recipe.class),
+                                                           mock(Recipe.class)));
+
+        assertEquals(List.of(false, false), result);
+        verifyNoInteractions(repo);
+    }
+
+    private static Recipe mockRecipe(long id) {
+        Recipe mock = mock(Recipe.class);
+        when(mock.getId()).thenReturn(id);
+        return mock;
+    }
+
+}


### PR DESCRIPTION
When performing library search, batch load "is favorite" instead of doing it recipe-by-recipe. While fav status is currently used for ordering results, I opted not to try and weave it into memory to avoid requerying as I did for pantry item use/dupe counts. Recipe search is going to evolve, since it's actually _search_ instead of just a listing, so opted to leave it simpler.