### PR TITLE
support create-from-source as well as create-blank and duplicate

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
@@ -31,8 +31,10 @@ public class PlannerMutation {
         return planService.createItem(parentId, afterId, name);
     }
 
-    public Plan createPlan(String name) {
-        return planService.createPlan(name);
+    public Plan createPlan(String name, Long sourcePlanId) {
+        return sourcePlanId == null
+                ? planService.createPlan(name)
+                : duplicatePlan(name, sourcePlanId);
     }
 
     public Deletion deleteBucket(Long planId, Long bucketId) {

--- a/src/main/resources/graphqls/planner.graphqls
+++ b/src/main/resources/graphqls/planner.graphqls
@@ -85,8 +85,8 @@ type PlannerMutation {
     the specified name.
     """
     createItem(parentId: ID!, afterId: ID, name: String!): PlanItem!
-    """Create a new empty plan."""
-    createPlan(name: String!): Plan!
+    """Create a new empty plan, optionally duplicating the specified source plan."""
+    createPlan(name: String!, sourcePlanId: ID): Plan!
     """Create a new plan by duplicating the specified source plan."""
     duplicatePlan(name: String!, sourcePlanId: ID!): Plan!
     """Delete a bucket from a plan."""

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
@@ -70,13 +70,26 @@ class PlannerMutationTest extends MockTest {
     }
 
     @Test
-    void createPlan() {
+    void createPlan_blank() {
         String name = "cheese party";
         Plan plan = mock(Plan.class);
         when(planService.createPlan(name))
                 .thenReturn(plan);
 
-        Plan result = mutation.createPlan(name);
+        Plan result = mutation.createPlan(name, null);
+
+        assertSame(plan, result);
+    }
+
+    @Test
+    void createPlan_from() {
+        String name = "cheese party";
+        long sourcePlanId = 456L;
+        Plan plan = mock(Plan.class);
+        when(planService.duplicatePlan(name, sourcePlanId))
+                .thenReturn(plan);
+
+        Plan result = mutation.createPlan(name, sourcePlanId);
 
         assertSame(plan, result);
     }


### PR DESCRIPTION
"Duplicate plan" was already present via a separate mutation, but that makes the client awkward. Add the ability to create by duplication, retaining create blank.

Closes #69