### PR TITLE
add doneAt date to setStatus mutation

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
@@ -73,8 +73,9 @@ public class PlannerMutation {
         return planService.setGrantOnPlan(planId, userId, accessLevel);
     }
 
-    public PlanItem setStatus(Long id, PlanItemStatus status) {
-        return planService.setItemStatus(id, status);
+    public PlanItem setStatus(Long id, PlanItemStatus status, LocalDate doneAt) {
+        if (doneAt == null) return planService.setItemStatus(id, status);
+        return planService.setItemStatus(id, status, doneAt);
     }
 
     public Plan revokeGrant(Long planId, Long userId) {

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
@@ -75,7 +75,6 @@ public class PlannerMutation {
     }
 
     public PlanItem setStatus(Long id, PlanItemStatus status, Instant doneAt) {
-        if (doneAt == null) return planService.setItemStatus(id, status);
         return planService.setItemStatus(id, status, doneAt);
     }
 

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
@@ -10,6 +10,7 @@ import com.brennaswitzer.cookbook.services.PlanService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -73,7 +74,7 @@ public class PlannerMutation {
         return planService.setGrantOnPlan(planId, userId, accessLevel);
     }
 
-    public PlanItem setStatus(Long id, PlanItemStatus status, LocalDate doneAt) {
+    public PlanItem setStatus(Long id, PlanItemStatus status, Instant doneAt) {
         if (doneAt == null) return planService.setItemStatus(id, status);
         return planService.setItemStatus(id, status, doneAt);
     }

--- a/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
@@ -389,11 +389,11 @@ public class PlanService {
     }
 
     public PlanItem setItemStatus(Long id, PlanItemStatus status) {
-        LocalDate now = LocalDate.now();
+        Instant now = Instant.now();
         return setItemStatus(id, status, now);
     }
 
-    public PlanItem setItemStatus(Long id, PlanItemStatus status, LocalDate doneAt) {
+    public PlanItem setItemStatus(Long id, PlanItemStatus status, Instant doneAt) {
         PlanItem item = getPlanItemById(id, AccessLevel.CHANGE);
         item.setStatus(status);
         if (item.getStatus().isForDelete()) {
@@ -405,14 +405,14 @@ public class PlanService {
 
     private void recordRecipeHistories(PlanItem item,
                                        PlanItemStatus status,
-                                       LocalDate doneAt) {
+                                       Instant doneAt) {
         if (Hibernate.unproxy(item.getIngredient()) instanceof Recipe r) {
             var h = new PlannedRecipeHistory();
             h.setRecipe(r);
             h.setOwner(principalAccess.getUser());
             h.setPlanItemId(item.getId());
             h.setPlannedAt(item.getCreatedAt());
-            h.setDoneAt(doneAt.atStartOfDay(ZoneId.systemDefault()).toInstant());
+            h.setDoneAt(doneAt);
             h.setStatus(status);
             recipeHistoryRepo.save(h);
         }

--- a/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
@@ -389,8 +389,7 @@ public class PlanService {
     }
 
     public PlanItem setItemStatus(Long id, PlanItemStatus status) {
-        Instant now = Instant.now();
-        return setItemStatus(id, status, now);
+        return setItemStatus(id, status, null);
     }
 
     public PlanItem setItemStatus(Long id, PlanItemStatus status, Instant doneAt) {
@@ -405,7 +404,8 @@ public class PlanService {
 
     private void recordRecipeHistories(PlanItem item,
                                        PlanItemStatus status,
-                                       Instant doneAt) {
+                                       Instant doneAtOrNull) {
+        Instant doneAt = doneAtOrNull == null ? Instant.now() : doneAtOrNull;
         if (Hibernate.unproxy(item.getIngredient()) instanceof Recipe r) {
             var h = new PlannedRecipeHistory();
             h.setRecipe(r);

--- a/src/main/resources/graphqls/planner.graphqls
+++ b/src/main/resources/graphqls/planner.graphqls
@@ -111,7 +111,7 @@ type PlannerMutation {
     setGrant(planId: ID!, userId: ID!, accessLevel:AccessLevel): Plan!
     """Sets the status of the given item. This will always return the updated
     item, though it may immediately moved to the trash (in the background)."""
-    setStatus(id: ID!, status: PlanItemStatus!): PlanItem!
+    setStatus(id: ID!, status: PlanItemStatus!, doneAt: Date): PlanItem!
     """Update a bucket w/in a plan, by setting or clearing its name and date."""
     updateBucket(planId: ID!, bucketId: ID!, name: String, date: Date): PlanBucket!
 }

--- a/src/main/resources/graphqls/planner.graphqls
+++ b/src/main/resources/graphqls/planner.graphqls
@@ -111,7 +111,7 @@ type PlannerMutation {
     setGrant(planId: ID!, userId: ID!, accessLevel:AccessLevel): Plan!
     """Sets the status of the given item. This will always return the updated
     item, though it may immediately moved to the trash (in the background)."""
-    setStatus(id: ID!, status: PlanItemStatus!, doneAt: Date): PlanItem!
+    setStatus(id: ID!, status: PlanItemStatus!, doneAt: DateTime): PlanItem!
     """Update a bucket w/in a plan, by setting or clearing its name and date."""
     updateBucket(planId: ID!, bucketId: ID!, name: String, date: Date): PlanBucket!
 }

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
@@ -11,7 +11,9 @@ import com.brennaswitzer.cookbook.util.MockTestTarget;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
 
@@ -206,7 +208,7 @@ class PlannerMutationTest extends MockTest {
         long id = 123L;
         PlanItemStatus status = PlanItemStatus.ACQUIRED;
         PlanItem item = mock(PlanItem.class);
-        LocalDate date = LocalDate.of(2024, 6, 4);
+        Instant date = Instant.now().minus(3, ChronoUnit.DAYS);
         when(planService.setItemStatus(id, status, date))
                 .thenReturn(item);
 

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
@@ -218,19 +218,6 @@ class PlannerMutationTest extends MockTest {
     }
 
     @Test
-    void setStatusNullDone() {
-        long id = 123L;
-        PlanItemStatus status = PlanItemStatus.ACQUIRED;
-        PlanItem item = mock(PlanItem.class);
-        when(planService.setItemStatus(id, status))
-                .thenReturn(item);
-
-        PlanItem result = mutation.setStatus(id, status, null);
-
-        assertSame(item, result);
-    }
-
-    @Test
     void revokeGrant() {
         long planId = 123L;
         long userId = 456L;
@@ -257,5 +244,4 @@ class PlannerMutationTest extends MockTest {
 
         assertSame(mock, bucket);
     }
-
 }

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
@@ -206,10 +206,24 @@ class PlannerMutationTest extends MockTest {
         long id = 123L;
         PlanItemStatus status = PlanItemStatus.ACQUIRED;
         PlanItem item = mock(PlanItem.class);
+        LocalDate date = LocalDate.of(2024, 6, 4);
+        when(planService.setItemStatus(id, status, date))
+                .thenReturn(item);
+
+        PlanItem result = mutation.setStatus(id, status, date);
+
+        assertSame(item, result);
+    }
+
+    @Test
+    void setStatusNullDone() {
+        long id = 123L;
+        PlanItemStatus status = PlanItemStatus.ACQUIRED;
+        PlanItem item = mock(PlanItem.class);
         when(planService.setItemStatus(id, status))
                 .thenReturn(item);
 
-        PlanItem result = mutation.setStatus(id, status);
+        PlanItem result = mutation.setStatus(id, status, null);
 
         assertSame(item, result);
     }

--- a/src/test/java/com/brennaswitzer/cookbook/services/PlanServiceTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/services/PlanServiceTest.java
@@ -246,14 +246,18 @@ class PlanServiceTest {
         assertEquals(PlanItemStatus.DELETED, h.getStatus());
         // pizza got completed
         h = byRecipe.get(box.pizza);
+        var pizzaHistory = byRecipe.get(box.pizza);
         assertEquals(pizza.getId(), h.getPlanItemId());
         assertNotNull(h.getPlannedAt());
         assertEquals(PlanItemStatus.COMPLETED, h.getStatus());
         // sauce got (implicitly) completed
         h = byRecipe.get(box.pizzaSauce);
+        var sauceHistory = byRecipe.get(box.pizzaSauce);
         assertEquals(sauce.getId(), h.getPlanItemId());
         assertNotNull(h.getPlannedAt());
         assertEquals(PlanItemStatus.COMPLETED, h.getStatus());
+        assertEquals(pizzaHistory.getDoneAt(), sauceHistory.getDoneAt());
+
         // ignore tomatoes - not a recipe
         assertEquals(3, recipeHistoryRepo.count());
     }


### PR DESCRIPTION
This adds an optional `doneAt` Date scalar to the `setStatus` mutation on the planner. This piece of data will allow us to "complete" a recipe on a day that is not today. Which, as it turns out, is kind of a thing for me.

To test out the mutation:

```
mutation setStatus($id: ID!, $status: PlanItemStatus!, $doneAt: Date) {
  planner {
    setStatus(id: $id, status: $status, doneAt: $doneAt) {
      id
    }
  }
}
```