### PR TITLE
batch load units for graphql queries

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/domain/Quantity.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/Quantity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.val;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.Comparator;
 import java.util.HashSet;
@@ -63,6 +64,7 @@ public class Quantity {
     private double quantity;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @BatchSize(size = 10)
     private UnitOfMeasure units;
 
     public Quantity() {

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/loaders/UnitOfMeasureBatchLoader.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/loaders/UnitOfMeasureBatchLoader.java
@@ -1,0 +1,35 @@
+package com.brennaswitzer.cookbook.graphql.loaders;
+
+import com.brennaswitzer.cookbook.domain.Identified;
+import com.brennaswitzer.cookbook.domain.UnitOfMeasure;
+import com.brennaswitzer.cookbook.repositories.UnitOfMeasureRepository;
+import org.dataloader.BatchLoader;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class UnitOfMeasureBatchLoader implements BatchLoader<Long, UnitOfMeasure> {
+
+    @Autowired
+    private UnitOfMeasureRepository repo;
+
+    @Override
+    public CompletionStage<List<UnitOfMeasure>> load(List<Long> uomIds) {
+        Map<Long, UnitOfMeasure> byId = repo.findAllById(new HashSet<>(uomIds)).stream()
+                .collect(Collectors.toMap(Identified::getId,
+                                          Function.identity()));
+        return CompletableFuture.completedStage(
+                uomIds.stream()
+                        .map(byId::get)
+                        .toList());
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/resolvers/QuantityResolver.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/resolvers/QuantityResolver.java
@@ -1,0 +1,22 @@
+package com.brennaswitzer.cookbook.graphql.resolvers;
+
+import com.brennaswitzer.cookbook.domain.Quantity;
+import com.brennaswitzer.cookbook.domain.UnitOfMeasure;
+import com.brennaswitzer.cookbook.graphql.loaders.UnitOfMeasureBatchLoader;
+import graphql.kickstart.tools.GraphQLResolver;
+import graphql.schema.DataFetchingEnvironment;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
+
+@Component
+public class QuantityResolver implements GraphQLResolver<Quantity> {
+
+    public CompletableFuture<UnitOfMeasure> units(Quantity q,
+                                                  DataFetchingEnvironment env) {
+        UnitOfMeasure uom = q.getUnits();
+        return env.<Long, UnitOfMeasure>getDataLoader(UnitOfMeasureBatchLoader.class.getName())
+                .load(uom == null ? null : uom.getId());
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/UnitOfMeasureRepository.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/UnitOfMeasureRepository.java
@@ -1,0 +1,6 @@
+package com.brennaswitzer.cookbook.repositories;
+
+import com.brennaswitzer.cookbook.domain.UnitOfMeasure;
+
+public interface UnitOfMeasureRepository extends BaseEntityRepository<UnitOfMeasure> {
+}


### PR DESCRIPTION
Instead of letting Hibernate lazy-load `UnitOfMeasure`s one at a time off `Quantity` fields, collect the IDs and batch load them.