### PR TITLE
Calendar spiffs

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/services/EmptyTrashBins.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/EmptyTrashBins.java
@@ -21,7 +21,7 @@ public class EmptyTrashBins {
 
     @Scheduled(cron = "${random.int[60]} ${random.int[60]} * * * *")
     public void emptyTrashBins() {
-        val cutoff = Instant.now().minus(7, ChronoUnit.DAYS);
+        val cutoff = Instant.now().minus(30, ChronoUnit.DAYS);
         val n = planItemRepository.deleteByUpdatedAtBeforeAndTrashBinIsNotNull(cutoff);
         log.info("Deleted {} old item(s) from the trash bin", n);
     }

--- a/src/main/java/com/brennaswitzer/cookbook/services/PlanCalendar.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/PlanCalendar.java
@@ -34,7 +34,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Comparator;
@@ -114,7 +114,7 @@ public class PlanCalendar {
         java.util.Date dt = java.util.Date.from(
                 item.getBucket()
                         .getDate()
-                        .atStartOfDay(ZoneId.systemDefault())
+                        .atStartOfDay(ZoneOffset.UTC)
                         .toInstant());
         return new DtStart(new Date(dt));
     }

--- a/src/main/java/com/brennaswitzer/cookbook/web/SharedPlanController.java
+++ b/src/main/java/com/brennaswitzer/cookbook/web/SharedPlanController.java
@@ -30,16 +30,20 @@ public class SharedPlanController {
     private PlanCalendar planCalendar;
 
     @GetMapping(
-            value = "/{slug}/{secret}/{id}.ics")
+            value = "/{slug}/{secret}/{id}.{ext:ics|txt}")
     public void getPlanCalendar(
             @PathVariable("secret") String secret,
             @PathVariable("id") Long id,
+            @PathVariable("ext") String ext,
             HttpServletResponse response) throws IOException {
         if (!helper.isSecretValid(Plan.class, id, secret)) {
             throw new AuthorizationServiceException("Bad secret");
         }
         response.setCharacterEncoding("UTF-8");
-        response.addHeader(HttpHeaders.CONTENT_TYPE, "text/calendar");
+        response.addHeader(HttpHeaders.CONTENT_TYPE, switch (ext) {
+            case "txt" -> "text/plain";
+            default -> "text/calendar";
+        });
         new CalendarOutputter(calendarProperties.isValidate())
                 .output(planCalendar.getCalendar(id),
                         response.getWriter());


### PR DESCRIPTION
Keep the trash around for 30 days (vs seven), allow pulling a plain-text calendar, and explicitly use UTC instead of relying on the system default.