### PR TITLE
plan items whose names start with a bang are excluded from ingredient recognition

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/services/ItemService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/ItemService.java
@@ -176,11 +176,16 @@ public class ItemService {
                 .collect(Collectors.toList());
     }
 
-    public void updateAutoRecognition(MutableItem it) {
+    public void clearAutoRecognition(MutableItem it) {
         if (it == null) return;
         it.setIngredient(null);
         it.setQuantity(null);
         it.setPreparation(null);
+    }
+
+    public void updateAutoRecognition(MutableItem it) {
+        if (it == null) return;
+        clearAutoRecognition(it);
         autoRecognize(it);
     }
 

--- a/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
@@ -289,7 +289,9 @@ public class PlanService {
         PlanItem parent = getPlanItemById(parentId, AccessLevel.CHANGE);
         PlanItem after = afterId == null ? null : getPlanItemById(afterId, AccessLevel.VIEW);
         PlanItem item = itemRepo.save(new PlanItem(name).of(parent, after));
-        itemService.autoRecognize(item);
+        if (!isRecognitionDisallowed(item)) {
+            itemService.autoRecognize(item);
+        }
         if (item.getId() == null) itemRepo.flush();
         return item;
     }
@@ -369,10 +371,16 @@ public class PlanService {
     public PlanItem renameItem(Long id, String name) {
         PlanItem item = getPlanItemById(id, AccessLevel.CHANGE);
         item.setName(name);
-        if (!item.hasIngredient() || !(Hibernate.unproxy(item.getIngredient()) instanceof Recipe)) {
+        if (isRecognitionDisallowed(item)) {
+            itemService.clearAutoRecognition(item);
+        } else if (!item.hasIngredient() || !(Hibernate.unproxy(item.getIngredient()) instanceof Recipe)) {
             itemService.updateAutoRecognition(item);
         }
         return item;
+    }
+
+    private boolean isRecognitionDisallowed(PlanItem item) {
+        return item.getName().startsWith("!");
     }
 
     public PlanMessage renameItemForMessage(Long id, String name) {


### PR DESCRIPTION
Plan items whose names start with a bang will never be recognized as an ingredient, and if they have a reference (e.g., a library recipe sent to plan) it will be stripped.

closes #86