### PR TITLE
Include photo on copy

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/domain/Photo.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/Photo.java
@@ -14,9 +14,6 @@ public class Photo {
 
     @Embedded
     private S3File file;
-    public void clearFile() {
-        file = null;
-    }
     public boolean hasFile() {
         return file != null;
     }
@@ -56,6 +53,12 @@ public class Photo {
 
     public Long getSize() {
         return file.getSize();
+    }
+
+    public void clear() {
+        file = null;
+        focusLeft = null;
+        focusTop = null;
     }
 
 }

--- a/src/main/java/com/brennaswitzer/cookbook/domain/Photo.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/Photo.java
@@ -47,6 +47,10 @@ public class Photo {
         return file.getObjectKey();
     }
 
+    public String getFilename() {
+        return file.getFilename();
+    }
+
     public String getContentType() {
         return file.getContentType();
     }

--- a/src/main/java/com/brennaswitzer/cookbook/domain/Recipe.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/Recipe.java
@@ -82,7 +82,7 @@ public class Recipe extends Ingredient implements AggregateIngredient, Owned {
     }
     public void clearPhoto() {
         if (hasPhoto()) {
-            photo.clearFile();
+            photo.clear();
         }
     }
     public boolean hasPhoto() {

--- a/src/main/java/com/brennaswitzer/cookbook/domain/Recipe.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/Recipe.java
@@ -13,7 +13,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import lombok.Getter;
 import lombok.Setter;
@@ -129,7 +128,7 @@ public class Recipe extends Ingredient implements AggregateIngredient, Owned {
         ingredients.add(new IngredientRef(raw));
     }
 
-    @PrePersist
+    @Override
     protected void onPrePersist() {
         super.onPrePersist();
         ensureRefOrder();

--- a/src/main/java/com/brennaswitzer/cookbook/domain/S3File.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/S3File.java
@@ -36,4 +36,8 @@ public class S3File {
 
     private Long size; // needs to be nullable for historical data
 
+    public String getFilename() {
+        return lastSegment(objectKey, '/');
+    }
+
 }

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/LibraryMutation.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/LibraryMutation.java
@@ -37,6 +37,13 @@ public class LibraryMutation {
         return recipe;
     }
 
+    public Recipe createRecipeFrom(Long sourceRecipeId, IngredientInfo info, Part photo) {
+        Recipe recipe = info.asRecipe(entityManager);
+        recipe = recipeService.createNewRecipeFrom(sourceRecipeId, recipe, Upload.of(photo));
+        labelService.updateLabels(recipe, info.getLabels());
+        return recipe;
+    }
+
     public Recipe updateRecipe(Long id, IngredientInfo info, Part photo) {
         info.setId(id);
         Recipe recipe = info.asRecipe(entityManager);

--- a/src/main/java/com/brennaswitzer/cookbook/services/LocalStorageService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/LocalStorageService.java
@@ -13,6 +13,13 @@ public class LocalStorageService implements StorageService {
     }
 
     @Override
+    public String copy(String source, String dest) {
+        Assert.notNull(source, "source is required.");
+        Assert.notNull(dest, "dest is required.");
+        return "images/pork_chops.jpg";
+    }
+
+    @Override
     public String load(String filename) {
         Assert.notNull(filename, "Filename is required");
         return "images/pork_chops.jpg";

--- a/src/main/java/com/brennaswitzer/cookbook/services/S3StorageService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/S3StorageService.java
@@ -32,6 +32,14 @@ public class S3StorageService implements StorageService {
     }
 
     @Override
+    public String copy(String source, String dest) {
+        Assert.notNull(source, "source is required.");
+        Assert.notNull(dest, "dest is required.");
+        client.copyObject(bucketName, source, bucketName, dest);
+        return dest;
+    }
+
+    @Override
     public String load(String objectKey) {
         Assert.notNull(objectKey, "objectKey is required");
         return "https://s3-" + region + ".amazonaws.com" + "/" + bucketName + "/" + objectKey;

--- a/src/main/java/com/brennaswitzer/cookbook/services/StorageService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/StorageService.java
@@ -5,11 +5,21 @@ import com.brennaswitzer.cookbook.domain.Upload;
 public interface StorageService {
 
     /**
-     * I take a Upload object and a string filename/key and write to storage
+     * I take an Upload object and a string filename/key and write to storage
      * @param filename String filename for storage
      * @return reference to the stored file
      */
     String store(Upload upload, String filename);
+
+    /**
+     * I take two string filename/keys and copy the content of the first to the
+     * second. A complete copy is made, no backreferences are created.
+     *
+     * @param source String filename to copy from
+     * @param dest   String filename to copy to
+     * @return reference to the stored (destination) file
+     */
+    String copy(String source, String dest);
 
     /**
      * I return a fully-qualified URL for the passed file reference.

--- a/src/main/resources/graphqls/library.graphqls
+++ b/src/main/resources/graphqls/library.graphqls
@@ -208,9 +208,22 @@ extend type Mutation {
 }
 
 type LibraryMutation {
+    """Create a new recipe in your library, from the passed info.
+    """
     createRecipe(info: IngredientInfo!, photo: Upload, cookThis: Boolean): Recipe!
+    """Create a new recipe in your library, from the passed info, which is based
+    on the passed source recipe id.
+    """
+    createRecipeFrom(sourceRecipeId: ID!, info: IngredientInfo!, photo: Upload): Recipe!
+    """Update a recipe in your library, from the passed info.
+    """
     updateRecipe(id: ID!, info: IngredientInfo!, photo: Upload): Recipe!
+    """Set the photo for a recipe in your library, without changing any other
+    info about the recipe. A photo may be set during create and/or update.
+    """
     setRecipePhoto(id: ID!, photo: Upload!): Recipe!
+    """Delete a recipe from your library.
+    """
     deleteRecipe(id: ID!): Deletion!
     history(recipeId: ID!): RecipeHistoryMutation
 }

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/LibraryMutationTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/LibraryMutationTest.java
@@ -89,6 +89,24 @@ class LibraryMutationTest extends MockTest {
     }
 
     @Test
+    void createRecipeFrom() {
+        var recipe = mock(Recipe.class);
+        List<String> labels = new ArrayList<>();
+        var info = mock(IngredientInfo.class);
+        when(info.getLabels()).thenReturn(labels);
+        when(info.asRecipe(any())).thenReturn(recipe);
+        when(recipeService.createNewRecipeFrom(any(), any(), any()))
+                .thenAnswer(iom -> iom.getArgument(1));
+
+        var result = mutation.createRecipeFrom(123L, info, null);
+
+        assertSame(recipe, result);
+        verify(info).asRecipe(entityManager);
+        verify(recipeService).createNewRecipeFrom(eq(123L), same(recipe), isNull());
+        verify(labelService).updateLabels(same(recipe), same(labels));
+    }
+
+    @Test
     void updateRecipe() {
         var recipe = mock(Recipe.class);
         List<String> labels = new ArrayList<>();


### PR DESCRIPTION
Allow creating a new recipe to indicate a source recipe it was copied from, and if the new recipe doesn't supply a photo, copy the source recipe's photo (if it has one).