### PR TITLE
support a String-typed color property on Plan

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/domain/Plan.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/Plan.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.BatchSize;
+import org.springframework.util.StringUtils;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -30,6 +31,8 @@ public class Plan extends PlanItem implements AccessControlled {
     @OneToMany(mappedBy = "trashBin", cascade = CascadeType.ALL)
     @BatchSize(size = 50)
     private Set<PlanItem> trashBinItems;
+
+    private String color;
 
     public Plan() {
     }
@@ -81,6 +84,35 @@ public class Plan extends PlanItem implements AccessControlled {
 
     public User getOwner() {
         return getAcl().getOwner();
+    }
+
+    public String getColor() {
+        if (color == null) {
+            // generated at http://medialab.github.io/iwanthue/
+            color = switch ((int) (get_eqkey() % 16)) {
+                case 0 -> "#cb4771";
+                case 1 -> "#caa29e";
+                case 2 -> "#783b32";
+                case 3 -> "#d14f32";
+                case 4 -> "#c9954c";
+                case 5 -> "#cbd152";
+                case 6 -> "#56713c";
+                case 7 -> "#6dce55";
+                case 8 -> "#8dd4aa";
+                case 9 -> "#77adc2";
+                case 10 -> "#6a7dc8";
+                case 11 -> "#3b3a41";
+                case 12 -> "#7145ca";
+                case 13 -> "#552b6b";
+                case 14 -> "#c583bd";
+                default -> "#cc4ac0";
+            };
+        }
+        return color;
+    }
+
+    public void setColor(String color) {
+        this.color = StringUtils.hasText(color) ? color : null;
     }
 
 }

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
@@ -81,6 +81,10 @@ public class PlannerMutation {
         return planService.updateBucket(planId, bucketId, name, date);
     }
 
+    public Plan setColor(Long planId, String color) {
+        return planService.setColor(planId, color);
+    }
+
     public Plan setGrant(Long planId, Long userId, AccessLevel accessLevel) {
         return planService.setGrantOnPlan(planId, userId, accessLevel);
     }

--- a/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
@@ -514,4 +514,10 @@ public class PlanService {
         return plan;
     }
 
+    public Plan setColor(Long planId, String color) {
+        Plan plan = getPlanById(planId, AccessLevel.ADMINISTER);
+        plan.setColor(color);
+        return plan;
+    }
+
 }

--- a/src/main/resources/db/changelog/gobrennas-2024.sql
+++ b/src/main/resources/db/changelog/gobrennas-2024.sql
@@ -461,3 +461,7 @@ where exists (select *
 --changeset barneyb:index-cook-history-owner-status
 CREATE INDEX idx_planned_recipe_history_owner_status
     ON planned_recipe_history (owner_id, status_id);
+
+--changeset barneyb:plan-color
+ALTER TABLE plan_item
+    ADD color VARCHAR;

--- a/src/main/resources/graphqls/planner.graphqls
+++ b/src/main/resources/graphqls/planner.graphqls
@@ -24,6 +24,10 @@ type Plan implements Node & Owned & AccessControlled & CorePlanItem  {
     id: ID!
     owner: User!
     name: String!
+    """The color associated with the plan, expressed as a number sign and six
+    hex digits (e.g., '#F57F17').
+    """
+    color: String!
     """A plan's plan is always itself."""
     plan: Plan!
     share: ShareInfo
@@ -110,8 +114,10 @@ type PlannerMutation {
     an item under a different parent is included in the list, it will be moved
     under this item."""
     reorderSubitems(parentId:ID!, itemIds: [ID!]!): PlanItem
+    """Set the plan's color (e.g., '#F57F17'), or reset it with a null or empty string."""
+    setColor(planId: ID!, color: String): Plan!
     """Set the access level granted to a user w/in a plan."""
-    setGrant(planId: ID!, userId: ID!, accessLevel:AccessLevel): Plan!
+    setGrant(planId: ID!, userId: ID!, accessLevel: AccessLevel): Plan!
     """Sets the status of the given item. This will always return the updated
     item, though it may immediately moved to the trash (in the background)."""
     setStatus(id: ID!, status: PlanItemStatus!, doneAt: DateTime): PlanItem!


### PR DESCRIPTION
Plans carry an explicit color, which may be `null`. If unset, a color stably computed from the `eq_key` will be used, so it will be stable across persistence boundaries. The same options are used as the client, but the hash function is different, so the effective mapping will also differ.