### PR TITLE
support a String-typed color property on Plan

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/domain/Plan.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/Plan.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.BatchSize;
+import org.springframework.util.StringUtils;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -16,6 +17,25 @@ import java.util.Set;
 @Entity
 @DiscriminatorValue("plan")
 public class Plan extends PlanItem implements AccessControlled {
+
+    // generated at http://medialab.github.io/iwanthue/
+    private static final String[] COLORS = {
+            "#cb4771",
+            "#caa29e",
+            "#783b32",
+            "#d14f32",
+            "#c9954c",
+            "#cbd152",
+            "#56713c",
+            "#6dce55",
+            "#8dd4aa",
+            "#77adc2",
+            "#6a7dc8",
+            "#3b3a41",
+            "#7145ca",
+            "#552b6b",
+            "#c583bd",
+            "#cc4ac0" };
 
     @Embedded
     @NotNull
@@ -30,6 +50,8 @@ public class Plan extends PlanItem implements AccessControlled {
     @OneToMany(mappedBy = "trashBin", cascade = CascadeType.ALL)
     @BatchSize(size = 50)
     private Set<PlanItem> trashBinItems;
+
+    private String color;
 
     public Plan() {
     }
@@ -81,6 +103,17 @@ public class Plan extends PlanItem implements AccessControlled {
 
     public User getOwner() {
         return getAcl().getOwner();
+    }
+
+    public String getColor() {
+        if (color == null) {
+            color = COLORS[(int) (get_eqkey() % COLORS.length)];
+        }
+        return color;
+    }
+
+    public void setColor(String color) {
+        this.color = StringUtils.hasText(color) ? color : null;
     }
 
 }

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
@@ -81,6 +81,10 @@ public class PlannerMutation {
         return planService.updateBucket(planId, bucketId, name, date);
     }
 
+    public Plan setColor(Long planId, String color) {
+        return planService.setColor(planId, color);
+    }
+
     public Plan setGrant(Long planId, Long userId, AccessLevel accessLevel) {
         return planService.setGrantOnPlan(planId, userId, accessLevel);
     }

--- a/src/main/java/com/brennaswitzer/cookbook/payload/PlanItemInfo.java
+++ b/src/main/java/com/brennaswitzer/cookbook/payload/PlanItemInfo.java
@@ -7,10 +7,11 @@ import com.brennaswitzer.cookbook.domain.Quantity;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.Hibernate;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import static com.brennaswitzer.cookbook.util.IdUtils.toIdList;
 
@@ -19,7 +20,8 @@ import static com.brennaswitzer.cookbook.util.IdUtils.toIdList;
 @SuppressWarnings("WeakerAccess")
 public class PlanItemInfo {
 
-    public static PlanItemInfo fromPlanItem(PlanItem item) {
+    public static PlanItemInfo from(PlanItem item) {
+        item = (PlanItem) Hibernate.unproxy(item);
         PlanItemInfo info = new PlanItemInfo();
         info.id = item.getId();
         info.name = item.getName();
@@ -52,31 +54,22 @@ public class PlanItemInfo {
         if (item.hasBucket()) {
             info.bucketId = item.getBucket().getId();
         }
-        return info;
-    }
-
-    public static PlanItemInfo fromPlan(Plan plan) {
-        PlanItemInfo info = fromPlanItem(plan);
-        info.acl = AclInfo.fromAcl(plan.getAcl());
-        info.color = plan.getColor();
-        if (plan.hasBuckets()) {
-            info.buckets = plan.getBuckets().stream()
-                    .map(PlanBucketInfo::from)
-                    .collect(Collectors.toList());
+        if (item instanceof Plan plan) {
+            info.acl = AclInfo.fromAcl(plan.getAcl());
+            info.color = plan.getColor();
+            if (plan.hasBuckets()) {
+                info.buckets = plan.getBuckets().stream()
+                        .map(PlanBucketInfo::from)
+                        .collect(Collectors.toList());
+            }
         }
         return info;
     }
 
-    public static List<PlanItemInfo> fromPlanItems(Iterable<PlanItem> items) {
-        return StreamSupport.stream(items.spliterator(), false)
-                .map(PlanItemInfo::fromPlanItem)
-                .collect(Collectors.toList());
-    }
-
-    public static List<PlanItemInfo> fromPlans(Iterable<Plan> plans) {
-        return StreamSupport.stream(plans.spliterator(), false)
-                .map(PlanItemInfo::fromPlan)
-                .collect(Collectors.toList());
+    public static List<PlanItemInfo> from(Iterable<? extends PlanItem> items) {
+        List<PlanItemInfo> result = new ArrayList<>();
+        for (var it : items) result.add(from(it));
+        return result;
     }
 
     private Long id;
@@ -94,13 +87,6 @@ public class PlanItemInfo {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private AclInfo acl;
 
-    /*
-     The use of NON_EMPTY here is a complete kludge, so when a PlanItem-typed
-     Plan is serialized, it won't carry a null color. The client's synchronizer
-     ends up getting such plans due to Hibernate's non-polymorphic proxies over
-     the PlanItem hierarchy. It's a mess.
-     */
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private String color;
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/src/main/java/com/brennaswitzer/cookbook/payload/PlanItemInfo.java
+++ b/src/main/java/com/brennaswitzer/cookbook/payload/PlanItemInfo.java
@@ -14,6 +14,8 @@ import java.util.stream.StreamSupport;
 
 import static com.brennaswitzer.cookbook.util.IdUtils.toIdList;
 
+@Setter
+@Getter
 @SuppressWarnings("WeakerAccess")
 public class PlanItemInfo {
 
@@ -56,6 +58,7 @@ public class PlanItemInfo {
     public static PlanItemInfo fromPlan(Plan plan) {
         PlanItemInfo info = fromPlanItem(plan);
         info.acl = AclInfo.fromAcl(plan.getAcl());
+        info.color = plan.getColor();
         if (plan.hasBuckets()) {
             info.buckets = plan.getBuckets().stream()
                     .map(PlanBucketInfo::from)
@@ -76,76 +79,49 @@ public class PlanItemInfo {
                 .collect(Collectors.toList());
     }
 
-    @Getter
-    @Setter
     private Long id;
 
-    @Getter
-    @Setter
     private String name;
 
-    @Getter
-    @Setter
     private String notes;
 
-    @Getter
-    @Setter
     private PlanItemStatus status;
 
-    @Getter
-    @Setter
     private Long parentId;
 
-    @Getter
-    @Setter
     private Long aggregateId;
 
-    @Getter
-    @Setter
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private AclInfo acl;
 
-    @Getter
-    @Setter
+    /*
+     The use of NON_EMPTY here is a complete kludge, so when a PlanItem-typed
+     Plan is serialized, it won't carry a null color. The client's synchronizer
+     ends up getting such plans due to Hibernate's non-polymorphic proxies over
+     the PlanItem hierarchy. It's a mess.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private String color;
+
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<PlanBucketInfo> buckets;
 
-    @Getter
-    @Setter
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private long[] subtaskIds;
 
-    @Getter
-    @Setter
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private long[] componentIds;
 
-    @Getter
-    @Setter
     private Double quantity;
 
-    @Getter
-    @Setter
     private String units;
 
-    @Getter
-    @Setter
     private Long uomId;
 
-    @Getter
-    @Setter
     private Long ingredientId;
 
-    @Getter
-    @Setter
     private Long bucketId;
 
-    @Getter
-    @Setter
     private String preparation;
-
-    public boolean hasSubtasks() {
-        return subtaskIds != null && subtaskIds.length > 0;
-    }
 
 }

--- a/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
@@ -244,7 +244,7 @@ public class PlanService {
         m.setId(parent.getId());
         m.setType("create");
         List<PlanItem> tree = getTreeById(parent);
-        m.setInfo(PlanItemInfo.fromPlanItems(tree));
+        m.setInfo(PlanItemInfo.from(tree));
         return m;
     }
 
@@ -418,7 +418,7 @@ public class PlanService {
         PlanMessage m = new PlanMessage();
         m.setId(item.getId());
         m.setType("update");
-        m.setInfo(PlanItemInfo.fromPlanItem(item));
+        m.setInfo(PlanItemInfo.from(item));
         return m;
     }
 

--- a/src/main/java/com/brennaswitzer/cookbook/web/PlanController.java
+++ b/src/main/java/com/brennaswitzer/cookbook/web/PlanController.java
@@ -59,7 +59,7 @@ public class PlanController {
     @GetMapping("")
     @ResponseStatus(HttpStatus.OK)
     public List<PlanItemInfo> getPlans() {
-        return PlanItemInfo.fromPlans(planService.getPlans());
+        return PlanItemInfo.from(planService.getPlans());
     }
 
     @PostMapping("")
@@ -70,7 +70,7 @@ public class PlanController {
                 ? planService.duplicatePlan(info.getName(),
                                             info.getFromId())
                 : planService.createPlan(info.getName());
-        return PlanItemInfo.fromPlan(plan);
+        return PlanItemInfo.from(plan);
     }
 
     @GetMapping("/{id}")
@@ -78,7 +78,7 @@ public class PlanController {
     public PlanItemInfo getPlanItem(
             @PathVariable("id") Long id
     ) {
-        return PlanItemInfo.fromPlanItem(planService.getPlanItemById(id));
+        return PlanItemInfo.from(planService.getPlanItemById(id));
     }
 
     @GetMapping("/{id}/acl")
@@ -103,7 +103,7 @@ public class PlanController {
     public List<PlanItemInfo> getDescendants(
             @PathVariable("id") Long id
     ) {
-        return PlanItemInfo.fromPlanItems(
+        return PlanItemInfo.from(
                 planService.getTreeById(id));
     }
 
@@ -112,7 +112,7 @@ public class PlanController {
             @PathVariable("id") Long id,
             @RequestParam Long cutoff
     ) {
-        return PlanItemInfo.fromPlanItems(
+        return PlanItemInfo.from(
                 planService.getTreeDeltasById(
                         id,
                         Instant.ofEpochMilli(cutoff)));
@@ -245,7 +245,7 @@ public class PlanController {
     ) {
         Plan plan = planService.setGrantOnPlan(id, grant.getUserId(), grant.getAccessLevel());
         Acl acl = plan.getAcl();
-        User user = userRepo.getById(grant.getUserId());
+        User user = userRepo.getReferenceById(grant.getUserId());
         return GrantInfo.fromGrant(user, acl.getGrant(user));
     }
 

--- a/src/main/resources/db/changelog/gobrennas-2024.sql
+++ b/src/main/resources/db/changelog/gobrennas-2024.sql
@@ -461,3 +461,7 @@ where exists (select *
 --changeset barneyb:index-cook-history-owner-status
 CREATE INDEX idx_planned_recipe_history_owner_status
     ON planned_recipe_history (owner_id, status_id);
+
+--changeset barneyb:plan-color
+ALTER TABLE plan_item
+    ADD color VARCHAR;

--- a/src/main/resources/graphqls/planner.graphqls
+++ b/src/main/resources/graphqls/planner.graphqls
@@ -24,6 +24,10 @@ type Plan implements Node & Owned & AccessControlled & CorePlanItem  {
     id: ID!
     owner: User!
     name: String!
+    """The color associated with the plan, expressed as a number sign and six
+    hex digits (e.g., '#F57F17').
+    """
+    color: String!
     """A plan's plan is always itself."""
     plan: Plan!
     share: ShareInfo
@@ -110,8 +114,10 @@ type PlannerMutation {
     an item under a different parent is included in the list, it will be moved
     under this item."""
     reorderSubitems(parentId:ID!, itemIds: [ID!]!): PlanItem
+    """Set the plan's color (e.g., '#F57F17'), or reset it with a null or empty string."""
+    setColor(planId: ID!, color: String): Plan!
     """Set the access level granted to a user w/in a plan."""
-    setGrant(planId: ID!, userId: ID!, accessLevel:AccessLevel): Plan!
+    setGrant(planId: ID!, userId: ID!, accessLevel: AccessLevel): Plan!
     """Sets the status of the given item. This will always return the updated
     item, though it may immediately moved to the trash (in the background)."""
     setStatus(id: ID!, status: PlanItemStatus!, doneAt: DateTime): PlanItem!

--- a/src/test/java/com/brennaswitzer/cookbook/services/PlanServiceMockedTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/services/PlanServiceMockedTest.java
@@ -1,5 +1,6 @@
 package com.brennaswitzer.cookbook.services;
 
+import com.brennaswitzer.cookbook.domain.AccessLevel;
 import com.brennaswitzer.cookbook.domain.Plan;
 import com.brennaswitzer.cookbook.domain.PlanBucket;
 import com.brennaswitzer.cookbook.domain.PlanItem;
@@ -12,9 +13,13 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class PlanServiceMockedTest extends MockTest {
@@ -120,6 +125,34 @@ public class PlanServiceMockedTest extends MockTest {
         var result = service.getTreeDeltasById(groceries.getId(), cutoff);
 
         assertEquals(List.of(groceries), result);
+    }
+
+    @Test
+    void setColor() {
+        var plan = mock(Plan.class);
+        doReturn(plan).when(service).getPlanById(any(), any());
+
+        service.setColor(123L, "#F57F17");
+        service.setColor(123L, "#f57f17");
+        assertThrows(IllegalArgumentException.class,
+                     () -> service.setColor(123L, " #F57F17"));
+        assertThrows(IllegalArgumentException.class,
+                     () -> service.setColor(123L, "#f57f17 "));
+        assertThrows(IllegalArgumentException.class,
+                     () -> service.setColor(123L, "#F00"));
+        assertThrows(IllegalArgumentException.class,
+                     () -> service.setColor(123L, "red"));
+        service.setColor(123L, "");
+        service.setColor(123L, null);
+
+        var inOrder = inOrder(plan);
+        inOrder.verify(plan).setColor("#F57F17");
+        inOrder.verify(plan).setColor("#f57f17");
+        inOrder.verify(plan).setColor("");
+        inOrder.verify(plan).setColor(null);
+        inOrder.verifyNoMoreInteractions();
+        verify(service, times(4))
+                .getPlanById(123L, AccessLevel.ADMINISTER);
     }
 
 }


### PR DESCRIPTION
Plans carry an explicit color, which may be null. If unset, a color stably computed from the `eq_key` will be used, so it can cross the persistence boundary. The same options are used as the client, but the hash function is different, so the effective mapping will also differ.