### PR TITLE
GraphQL plan synchronizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ HELP.md
 /src/main/resources/application-default.yml
 /src/main/resources/application-dev.yml
 /src/main/resources/liquibase.properties
+/src/main/resources/graphql.config.yml
+/src/main/resources/gql
 
 ### STS ###
 .apt_generated

--- a/src/main/java/com/brennaswitzer/cookbook/domain/CorePlanItem.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/CorePlanItem.java
@@ -1,0 +1,7 @@
+package com.brennaswitzer.cookbook.domain;
+
+/**
+ * Marker interface to help kickstart.
+ */
+public interface CorePlanItem {
+}

--- a/src/main/java/com/brennaswitzer/cookbook/domain/PlanItem.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/PlanItem.java
@@ -42,7 +42,7 @@ import static jakarta.persistence.CascadeType.REFRESH;
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn
 @DiscriminatorValue("item")
-public class PlanItem extends BaseEntity implements Named, MutableItem {
+public class PlanItem extends BaseEntity implements Named, MutableItem, CorePlanItem {
 
     public static final Comparator<PlanItem> BY_ID = (a, b) -> {
         if (a == null) return b == null ? 0 : 1;

--- a/src/main/java/com/brennaswitzer/cookbook/domain/PlanItem.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/PlanItem.java
@@ -225,7 +225,7 @@ public class PlanItem extends BaseEntity implements Named, MutableItem {
     }
 
     public void setParent(PlanItem parent) {
-        PlanItem currentParent = (PlanItem) Hibernate.unproxy(getParent());
+        PlanItem currentParent = Hibernate.unproxy(getParent(), PlanItem.class);
         // see if it's a no-op
         if (Objects.equals(parent, currentParent)) {
             return;

--- a/src/main/java/com/brennaswitzer/cookbook/domain/Recipe.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/Recipe.java
@@ -153,7 +153,7 @@ public class Recipe extends Ingredient implements AggregateIngredient, Owned {
         if (ingredients == null) return refs;
         for (IngredientRef ref : ingredients) {
             if (!ref.hasIngredient()) continue;
-            Object ingredient = Hibernate.unproxy(ref.getIngredient());
+            var ingredient = Hibernate.unproxy(ref.getIngredient(), Ingredient.class);
             if (ingredient instanceof PantryItem) {
                 refs.add(ref);
             } else if (ingredient instanceof AggregateIngredient agg) {
@@ -178,7 +178,7 @@ public class Recipe extends Ingredient implements AggregateIngredient, Owned {
         if (ingredients == null) return refs;
         for (IngredientRef ref : ingredients) {
             if (ref.hasIngredient()) {
-                Object ingredient = Hibernate.unproxy(ref.getIngredient());
+                var ingredient = Hibernate.unproxy(ref.getIngredient(), Ingredient.class);
                 if (ingredient instanceof AggregateIngredient agg) {
                     refs.addAll(agg.assembleRawIngredientRefs());
                 }

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerMutation.java
@@ -1,6 +1,7 @@
 package com.brennaswitzer.cookbook.graphql;
 
 import com.brennaswitzer.cookbook.domain.AccessLevel;
+import com.brennaswitzer.cookbook.domain.CorePlanItem;
 import com.brennaswitzer.cookbook.domain.Plan;
 import com.brennaswitzer.cookbook.domain.PlanBucket;
 import com.brennaswitzer.cookbook.domain.PlanItem;
@@ -69,7 +70,7 @@ public class PlannerMutation {
         return planService.mutateTree(itemIds, parentId, afterId);
     }
 
-    public PlanItem rename(Long id, String name) {
+    public CorePlanItem rename(Long id, String name) {
         return planService.renameItem(id, name);
     }
 

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerQuery.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/PlannerQuery.java
@@ -1,14 +1,16 @@
 package com.brennaswitzer.cookbook.graphql;
 
+import com.brennaswitzer.cookbook.domain.CorePlanItem;
 import com.brennaswitzer.cookbook.domain.Plan;
 import com.brennaswitzer.cookbook.domain.PlanItem;
+import com.brennaswitzer.cookbook.graphql.support.PrincipalUtil;
 import com.brennaswitzer.cookbook.services.PlanService;
+import graphql.schema.DataFetchingEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 @Component
@@ -17,19 +19,22 @@ public class PlannerQuery {
     @Autowired
     private PlanService planService;
 
-    List<Plan> plans() {
+    List<Plan> plans(DataFetchingEnvironment env) {
         List<Plan> result = new ArrayList<>();
-        Iterable<Plan> plans = planService.getPlans();
-        Iterator<Plan> iterator = plans.iterator();
-        iterator.forEachRemaining(result::add);
+        planService.getPlans(PrincipalUtil.from(env).getId())
+                .forEach(result::add);
         return result;
+    }
+
+    Plan plan(Long id) {
+        return planService.getPlanById(id);
     }
 
     PlanItem planItem(Long id) {
         return planService.getPlanItemById(id);
     }
 
-    List<PlanItem> updatedSince(Long planId, Long cutoff) {
+    List<? extends CorePlanItem> updatedSince(Long planId, Long cutoff) {
         return planService.getTreeDeltasById(planId,
                                              Instant.ofEpochMilli(cutoff));
     }

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/resolvers/PlanItemResolver.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/resolvers/PlanItemResolver.java
@@ -1,8 +1,11 @@
 package com.brennaswitzer.cookbook.graphql.resolvers;
 
+import com.brennaswitzer.cookbook.domain.CorePlanItem;
+import com.brennaswitzer.cookbook.domain.Ingredient;
 import com.brennaswitzer.cookbook.domain.PlanItem;
 import com.brennaswitzer.cookbook.services.PlanService;
 import graphql.kickstart.tools.GraphQLResolver;
+import org.hibernate.Hibernate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -16,7 +19,11 @@ public class PlanItemResolver implements GraphQLResolver<PlanItem> {
     @Autowired
     private PlanService planService;
 
-    public PlanItem parent(PlanItem item) {
+    public Ingredient getIngredient(PlanItem item) {
+        return Hibernate.unproxy(item.getIngredient(), Ingredient.class);
+    }
+
+    public CorePlanItem parent(PlanItem item) {
         return item.getParent();
     }
 

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/resolvers/PlanResolver.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/resolvers/PlanResolver.java
@@ -1,5 +1,6 @@
 package com.brennaswitzer.cookbook.graphql.resolvers;
 
+import com.brennaswitzer.cookbook.domain.CorePlanItem;
 import com.brennaswitzer.cookbook.domain.Plan;
 import com.brennaswitzer.cookbook.domain.PlanItem;
 import com.brennaswitzer.cookbook.payload.ShareInfo;
@@ -9,6 +10,7 @@ import graphql.kickstart.tools.GraphQLResolver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.time.Instant;
 import java.util.List;
 
 import static com.brennaswitzer.cookbook.util.CollectionUtils.tail;
@@ -30,8 +32,8 @@ public class PlanResolver implements GraphQLResolver<Plan> {
         return plan.getOrderedChildView();
     }
 
-    public int descendantCount(Plan item) {
-        return planService.getTreeById(item).size() - 1;
+    public int descendantCount(Plan plan) {
+        return planService.getTreeById(plan).size() - 1;
     }
 
     public List<PlanItem> descendants(Plan plan) {
@@ -40,6 +42,11 @@ public class PlanResolver implements GraphQLResolver<Plan> {
 
     public ShareInfo share(Plan plan) {
         return shareHelper.getInfo(Plan.class, plan);
+    }
+
+    List<? extends CorePlanItem> updatedSince(Plan plan, Long cutoff) {
+        return planService.getTreeDeltasById(plan.getId(),
+                                             Instant.ofEpochMilli(cutoff));
     }
 
 }

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/resolvers/RecipeResolver.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/resolvers/RecipeResolver.java
@@ -1,6 +1,7 @@
 package com.brennaswitzer.cookbook.graphql.resolvers;
 
 import com.brennaswitzer.cookbook.domain.FavoriteType;
+import com.brennaswitzer.cookbook.domain.Ingredient;
 import com.brennaswitzer.cookbook.domain.IngredientRef;
 import com.brennaswitzer.cookbook.domain.Photo;
 import com.brennaswitzer.cookbook.domain.PlanItemStatus;
@@ -81,7 +82,7 @@ public class RecipeResolver implements GraphQLResolver<Recipe> {
         while (!queue.isEmpty()) {
             IngredientRef ir = queue.remove();
             if (!ir.hasIngredient()) continue;
-            Object ing = Hibernate.unproxy(ir.getIngredient());
+            var ing = Hibernate.unproxy(ir.getIngredient(), Ingredient.class);
             if (ing instanceof Recipe r && result.add(r)) {
                 queue.addAll(r.getIngredients());
             }

--- a/src/main/java/com/brennaswitzer/cookbook/payload/PlanItemInfo.java
+++ b/src/main/java/com/brennaswitzer/cookbook/payload/PlanItemInfo.java
@@ -21,7 +21,7 @@ import static com.brennaswitzer.cookbook.util.IdUtils.toIdList;
 public class PlanItemInfo {
 
     public static PlanItemInfo from(PlanItem item) {
-        item = (PlanItem) Hibernate.unproxy(item);
+        item = Hibernate.unproxy(item, PlanItem.class);
         PlanItemInfo info = new PlanItemInfo();
         info.id = item.getId();
         info.name = item.getName();

--- a/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/PlanService.java
@@ -103,7 +103,7 @@ public class PlanService {
                 principalAccess.getUser(),
                 requiredAccess
         );
-        return item;
+        return Hibernate.unproxy(item, PlanItem.class);
     }
 
     public Plan getPlanById(Long id) {
@@ -116,7 +116,7 @@ public class PlanService {
                 principalAccess.getUser(),
                 requiredAccess
         );
-        return plan;
+        return Hibernate.unproxy(plan, Plan.class);
     }
 
     public List<PlanItem> getTreeById(Long id) {
@@ -210,7 +210,7 @@ public class PlanService {
         if (scale == null || scale <= 0) { // nonsense!
             scale = 1d;
         }
-        Ingredient ingredient = (Ingredient) Hibernate.unproxy(ref.getIngredient());
+        Ingredient ingredient = Hibernate.unproxy(ref.getIngredient(), Ingredient.class);
         boolean isAggregate = ingredient instanceof AggregateIngredient;
         if (ref.hasQuantity()) {
             ref = ref.scale(scale);

--- a/src/main/java/com/brennaswitzer/cookbook/web/SharedRecipeController.java
+++ b/src/main/java/com/brennaswitzer/cookbook/web/SharedRecipeController.java
@@ -56,7 +56,7 @@ public class SharedRecipeController {
         while (!queue.isEmpty()) {
             IngredientRef ir = queue.remove();
             if (!ir.hasIngredient()) continue;
-            Object ing = Hibernate.unproxy(ir.getIngredient());
+            var ing = Hibernate.unproxy(ir.getIngredient(), Ingredient.class);
             if (ing instanceof Recipe r) {
                 ings.add(ingredientMapper.recipeToInfo(r));
             } else if (ing instanceof PantryItem pi) {

--- a/src/main/resources/graphqls/planner.graphqls
+++ b/src/main/resources/graphqls/planner.graphqls
@@ -4,10 +4,12 @@ extend type Query {
 
 type PlannerQuery {
     plans: [Plan]!
+    plan(id: ID!): Plan!
     planItem(id: ID!): PlanItem!
     """Retrieve all items on the given plan which have been updated since the
-    passed cutoff (expressed in milliseconds since the UNIX epoch)."""
-    updatedSince(planId: ID!, cutoff: Long): [PlanItem!]!
+    passed cutoff (expressed in milliseconds since the UNIX epoch). May include
+    the plan itself!"""
+    updatedSince(planId: ID!, cutoff: Long!): [CorePlanItem!]!
 }
 
 interface CorePlanItem implements Node {
@@ -22,39 +24,48 @@ interface CorePlanItem implements Node {
 
 type Plan implements Node & Owned & AccessControlled & CorePlanItem  {
     id: ID!
-    owner: User!
     name: String!
-    """The color associated with the plan, expressed as a number sign and six
-    hex digits (e.g., '#F57F17').
-    """
-    color: String!
     """A plan's plan is always itself."""
     plan: Plan!
-    share: ShareInfo
-    acl: Acl!
-    grants: [AccessControlEntry!]!
     childCount: NonNegativeInt!
     children: [PlanItem!]!
     descendantCount: NonNegativeInt!
     descendants: [PlanItem!]!
+    # extensions
+    """The color associated with the plan, expressed as a number sign and six
+    hex digits (e.g., '#F57F17').
+    """
+    color: String!
+    acl: Acl!
+    grants: [AccessControlEntry!]!
+    """The plan's owner
+    """
+    owner: User!
+    share: ShareInfo
     bucketCount: NonNegativeInt!
     buckets: [PlanBucket!]!
+    """Retrieve all items which have been updated since the passed cutoff
+    (expressed in milliseconds since the UNIX epoch). May include this plan!"""
+    updatedSince(cutoff: Long!): [CorePlanItem!]!
 }
 
 """Represents a single item on a plan"""
 type PlanItem implements Node & CorePlanItem {
     id: ID!
     name: String!
-    quantity: Quantity
-    preparation: String
-    ingredient: Ingredient
-    notes: String
     plan: Plan!
-    parent: PlanItem
     childCount: NonNegativeInt!
     children: [PlanItem!]!
     descendantCount: NonNegativeInt!
     descendants: [PlanItem!]!
+    # extensions
+    """This item's parent; follow enough and you'll always get to the plan.
+    """
+    parent: CorePlanItem
+    notes: String
+    quantity: Quantity
+    preparation: String
+    ingredient: Ingredient
     aggregate: PlanItem
     componentCount: NonNegativeInt!
     components: [PlanItem!]!
@@ -108,7 +119,7 @@ type PlannerMutation {
     specific item already under that parent. The parent's info is returned."""
     mutateTree(itemIds: [ID!]!, parentId: ID!, afterId: ID): PlanItem!
     """Update the name of the given plan or plan item (but not bucket)."""
-    rename(id: ID!, name: String!): PlanItem!
+    rename(id: ID!, name: String!): CorePlanItem!
     """Reorder the item/plan subitems in the same order as the passed list. If
     there are subitems not included in the list, they will not be reordered. If
     an item under a different parent is included in the list, it will be moved

--- a/src/main/resources/graphqls/profile.graphqls
+++ b/src/main/resources/graphqls/profile.graphqls
@@ -21,9 +21,9 @@ type Acl implements Owned {
 
 type AccessControlEntry {
     """The user who has been granted access to an AccessControlled object."""
-    user: User
+    user: User!
     """The level of access the user has been granted."""
-    level: AccessLevel
+    level: AccessLevel!
 }
 
 enum AccessLevel {

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/PlannerMutationTest.java
@@ -171,7 +171,7 @@ class PlannerMutationTest extends MockTest {
         when(planService.renameItem(id, newName))
                 .thenReturn(item);
 
-        PlanItem result = mutation.rename(id, newName);
+        var result = mutation.rename(id, newName);
 
         assertSame(item, result);
     }

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/resolvers/PlanItemResolverTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/resolvers/PlanItemResolverTest.java
@@ -34,7 +34,7 @@ class PlanItemResolverTest extends MockTest {
         when(plan.getParent()).thenReturn(null);
         when(plan.getPlan()).thenReturn(plan);
 
-        PlanItem p = resolver.parent(plan);
+        var p = resolver.parent(plan);
 
         assertNull(p, "Plan don't have parents");
     }
@@ -46,7 +46,7 @@ class PlanItemResolverTest extends MockTest {
         when(item.getParent()).thenReturn(plan);
         when(item.getPlan()).thenReturn(plan);
 
-        PlanItem p = resolver.parent(item);
+        var p = resolver.parent(item);
 
         assertSame(plan, p);
     }


### PR DESCRIPTION
Machinations to support synchronizing plans via GraphQL, instead of REST. Most of it is type shenanigans to support kickstart's runtime-reflection-based behavior. The only meaningful change is making ACE's user/grant fields non-nullable. That's how they should have been from the start, but I didn't notice until now.