### PR TITLE
on plan calendars, don't include recipes deleted w/in six hours of being planned

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/services/PlanCalendar.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/PlanCalendar.java
@@ -4,6 +4,7 @@ import com.brennaswitzer.cookbook.config.AppProperties;
 import com.brennaswitzer.cookbook.domain.Plan;
 import com.brennaswitzer.cookbook.domain.PlanBucket;
 import com.brennaswitzer.cookbook.domain.PlanItem;
+import com.brennaswitzer.cookbook.domain.PlanItemStatus;
 import com.brennaswitzer.cookbook.domain.User;
 import com.brennaswitzer.cookbook.repositories.PlanBucketRepository;
 import com.brennaswitzer.cookbook.repositories.PlanRepository;
@@ -148,9 +149,6 @@ public class PlanCalendar {
                 .getFluentTarget();
     }
 
-    /**
-     * I convert the passed stream of PlanItems to an iCal calendar.
-     */
     public Calendar getCalendar(long planId) {
         Plan plan = planRepo.getReferenceById(planId);
         FluentCalendar cal = new Calendar()
@@ -164,6 +162,8 @@ public class PlanCalendar {
                 .sorted(Comparator.comparing(PlanBucket::getDate))
                 .map(PlanBucket::getItems)
                 .flatMap(Collection::stream)
+                .filter(it -> it.getStatus() != PlanItemStatus.DELETED
+                              || Duration.between(it.getCreatedAt(), it.getUpdatedAt()).toHours() > 6)
                 .map(this::getEvent)
                 .forEach(cal::withComponent);
         return cal.getFluentTarget();

--- a/src/main/java/com/brennaswitzer/cookbook/web/SharedPlanController.java
+++ b/src/main/java/com/brennaswitzer/cookbook/web/SharedPlanController.java
@@ -40,10 +40,8 @@ public class SharedPlanController {
             throw new AuthorizationServiceException("Bad secret");
         }
         response.setCharacterEncoding("UTF-8");
-        response.addHeader(HttpHeaders.CONTENT_TYPE, switch (ext) {
-            case "txt" -> "text/plain";
-            default -> "text/calendar";
-        });
+        response.addHeader(HttpHeaders.CONTENT_TYPE,
+                           "txt".equals(ext) ? "text/plain" : "text/calendar");
         new CalendarOutputter(calendarProperties.isValidate())
                 .output(planCalendar.getCalendar(id),
                         response.getWriter());


### PR DESCRIPTION
When a recipe is planned, bucketed, and deleted w/in six hours, don't include it on the plan's calendar. The assumption is that such recipes are ephemeral artifacts of making a plan, not actually planned recipes.