### PR TITLE
add a logging instrumentation to GraphQL processing

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/graphql/instrumentation/GraphQLLoggingInstrumentation.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/instrumentation/GraphQLLoggingInstrumentation.java
@@ -1,0 +1,84 @@
+package com.brennaswitzer.cookbook.graphql.instrumentation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import graphql.ExecutionResult;
+import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.InstrumentationState;
+import graphql.execution.instrumentation.SimpleInstrumentationContext;
+import graphql.execution.instrumentation.SimplePerformantInstrumentation;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
+import org.apache.commons.text.StringEscapeUtils;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class GraphQLLoggingInstrumentation extends SimplePerformantInstrumentation {
+
+    private static final Logger logger = LoggerFactory.getLogger(GraphQLLoggingInstrumentation.class);
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Override
+    @NotNull
+    public InstrumentationContext<ExecutionResult> beginExecution(
+            InstrumentationExecutionParameters parameters,
+            InstrumentationState state) {
+        if (!logger.isInfoEnabled()) return SimpleInstrumentationContext.noOp();
+        var startMillis = System.currentTimeMillis();
+        return new SimpleInstrumentationContext<>() {
+            @Override
+            public void onCompleted(ExecutionResult executionResult, Throwable t) {
+                var elapsed = System.currentTimeMillis() - startMillis;
+                var executionId = parameters.getExecutionInput().getExecutionId();
+                var debugEnabled = logger.isDebugEnabled();
+                if (debugEnabled) {
+                    logger.debug("graphql {} query: \"{}\"",
+                                 executionId,
+                                 StringEscapeUtils.escapeJson(parameters.getQuery().strip()));
+                    logger.debug("graphql {} variables: {}",
+                                 executionId,
+                                 maybeAsJson(parameters.getVariables()));
+                }
+                if (t != null) {
+                    // SLF4J can EITHER interpolate OR log a Throwable.
+                    logger.error("graphql %s exception:".formatted(executionId), t);
+                }
+                for (var e : executionResult.getErrors()) {
+                    logger.warn("graphql {} error: {}",
+                                executionId,
+                                e);
+                }
+                if (debugEnabled && executionResult.isDataPresent()) {
+                    logger.debug("graphql {} data: {}",
+                                 executionId,
+                                 maybeAsJson(executionResult.<Object>getData()));
+                }
+                logger.info("graphql {} operation: {} {}ms",
+                            executionId,
+                            parameters.getOperation(),
+                            elapsed);
+            }
+        };
+    }
+
+    private Object maybeAsJson(Object o) {
+        return o instanceof Map<?, ?> m
+                ? maybeAsJson(m)
+                : o;
+    }
+
+    private Object maybeAsJson(Map<?, ?> m) {
+        try {
+            return objectMapper.writeValueAsString(m);
+        } catch (JsonProcessingException ignored) {}
+        return m;
+    }
+
+}


### PR DESCRIPTION
Normal access logging is useless for GraphQL requests, so roll some custom logging. Exceptions get logged at `ERROR`, GraphQL errors at `WARN`, operation name and execution time at `INFO`, and the query, variables, and result data at `DEBUG`. All lines have an `executionId` (a UUID) for correlation. Two pristine requests w/ `DEBUG` enabled:

```
2025-01-25T14:43:57.252-08:00 DEBUG 65083 --- [  XNIO-1 task-2] c.b.c.g.i.GraphQLLoggingInstrumentation  : graphql 64946b0a-111b-4e44-b6fe-a549708752e1 query: "query listAllFavorites {\n  favorite {\n    all {\n      id\n      objectType\n      objectId\n      __typename\n    }\n    __typename\n  }\n}"
2025-01-25T14:43:57.252-08:00 DEBUG 65083 --- [  XNIO-1 task-2] c.b.c.g.i.GraphQLLoggingInstrumentation  : graphql 64946b0a-111b-4e44-b6fe-a549708752e1 variables: {}
2025-01-25T14:43:57.252-08:00 DEBUG 65083 --- [  XNIO-1 task-2] c.b.c.g.i.GraphQLLoggingInstrumentation  : graphql 64946b0a-111b-4e44-b6fe-a549708752e1 data: {"favorite":{"all":[{"id":"8777749720530","objectType":"Recipe","objectId":"631","__typename":"Favorite"},{"id":"8777749723180","objectType":"Recipe","objectId":"8777749720830","__typename":"Favorite"},{"id":"8777749727281","objectType":"Recipe","objectId":"323","__typename":"Favorite"}],"__typename":"FavoriteQuery"}}
2025-01-25T14:43:57.252-08:00  INFO 65083 --- [  XNIO-1 task-2] c.b.c.g.i.GraphQLLoggingInstrumentation  : graphql 64946b0a-111b-4e44-b6fe-a549708752e1 operation: listAllFavorites 4ms
2025-01-25T14:43:57.808-08:00 DEBUG 65083 --- [  XNIO-1 task-6] c.b.c.g.i.GraphQLLoggingInstrumentation  : graphql 8f59be57-23ea-47d6-b574-fef0381219dc query: "query loadPlanItemAndDescendants($id: ID!) {\n  planner {\n    planOrItem(id: $id) {\n      ...corePlanItemLoad\n      ...planLoad\n      ...planItemLoad\n      descendants {\n        ...corePlanItemLoad\n        ...planItemLoad\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}\n\nfragment corePlanItemLoad on CorePlanItem {\n  id\n  name\n  children {\n    id\n    __typename\n  }\n  __typename\n}\n\nfragment planLoad on Plan {\n  color\n  owner {\n    id\n    __typename\n  }\n  grants {\n    user {\n      id\n      __typename\n    }\n    level\n    __typename\n  }\n  buckets {\n    id\n    date\n    name\n    __typename\n  }\n  __typename\n}\n\nfragment planItemLoad on PlanItem {\n  status\n  notes\n  parent {\n    id\n    __typename\n  }\n  aggregate {\n    id\n    __typename\n  }\n  preparation\n  ingredient {\n    id\n    __typename\n  }\n  quantity {\n    quantity\n    units {\n      name\n      id\n      __typename\n    }\n    __typename\n  }\n  components {\n    id\n    __typename\n  }\n  bucket {\n    id\n    __typename\n  }\n  __typename\n}"
2025-01-25T14:43:57.808-08:00 DEBUG 65083 --- [  XNIO-1 task-6] c.b.c.g.i.GraphQLLoggingInstrumentation  : graphql 8f59be57-23ea-47d6-b574-fef0381219dc variables: {"id":"8777749728231"}
2025-01-25T14:43:57.808-08:00 DEBUG 65083 --- [  XNIO-1 task-6] c.b.c.g.i.GraphQLLoggingInstrumentation  : graphql 8f59be57-23ea-47d6-b574-fef0381219dc data: {"planner":{"planOrItem":{"id":"8777749728231","name":"avocado","children":[],"__typename":"Plan","color":"#d14f32","owner":{"id":"8777749698959","__typename":"User"},"grants":[],"buckets":[],"descendants":[]},"__typename":"PlannerQuery"}}
2025-01-25T14:43:57.808-08:00  INFO 65083 --- [  XNIO-1 task-6] c.b.c.g.i.GraphQLLoggingInstrumentation  : graphql 8f59be57-23ea-47d6-b574-fef0381219dc operation: loadPlanItemAndDescendants 5ms

```