### PR TITLE
add a query for bulk ingredients to pantry/library

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/graphql/LibraryQuery.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/LibraryQuery.java
@@ -1,5 +1,6 @@
 package com.brennaswitzer.cookbook.graphql;
 
+import com.brennaswitzer.cookbook.domain.Ingredient;
 import com.brennaswitzer.cookbook.domain.Recipe;
 import com.brennaswitzer.cookbook.graphql.model.OffsetConnection;
 import com.brennaswitzer.cookbook.graphql.model.OffsetConnectionCursor;
@@ -7,6 +8,7 @@ import com.brennaswitzer.cookbook.graphql.support.PrincipalUtil;
 import com.brennaswitzer.cookbook.payload.RecognizedItem;
 import com.brennaswitzer.cookbook.repositories.SearchResponse;
 import com.brennaswitzer.cookbook.repositories.impl.LibrarySearchScope;
+import com.brennaswitzer.cookbook.services.IngredientService;
 import com.brennaswitzer.cookbook.services.ItemService;
 import com.brennaswitzer.cookbook.services.RecipeService;
 import com.brennaswitzer.cookbook.util.ShareHelper;
@@ -16,6 +18,7 @@ import jakarta.persistence.NoResultException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.Collection;
 import java.util.Set;
 
 @Component
@@ -26,6 +29,9 @@ public class LibraryQuery extends PagingQuery {
 
     @Autowired
     private ItemService itemService;
+
+    @Autowired
+    private IngredientService ingredientService;
 
     @Autowired
     private ShareHelper shareHelper;
@@ -65,6 +71,10 @@ public class LibraryQuery extends PagingQuery {
             OffsetConnectionCursor after) {
         SearchResponse<Recipe> rs = recipeService.suggestRecipes(getOffset(after), first);
         return new OffsetConnection<>(rs);
+    }
+
+    public Collection<Ingredient> bulkIngredients(Collection<Long> ids) {
+        return ingredientService.bulkIngredients(ids);
     }
 
     private void ensurePrincipalOrSecret(Long id,

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/PantryQuery.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/PantryQuery.java
@@ -1,11 +1,13 @@
 package com.brennaswitzer.cookbook.graphql;
 
+import com.brennaswitzer.cookbook.domain.Ingredient;
 import com.brennaswitzer.cookbook.domain.PantryItem;
 import com.brennaswitzer.cookbook.graphql.model.OffsetConnection;
 import com.brennaswitzer.cookbook.graphql.model.OffsetConnectionCursor;
 import com.brennaswitzer.cookbook.repositories.SearchResponse;
 import com.brennaswitzer.cookbook.repositories.impl.PantryItemSearchRequest;
 import com.brennaswitzer.cookbook.repositories.impl.SortDir;
+import com.brennaswitzer.cookbook.services.IngredientService;
 import com.brennaswitzer.cookbook.services.PantryItemService;
 import graphql.relay.Connection;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 @Component
@@ -24,6 +27,9 @@ public class PantryQuery extends PagingQuery {
 
     @Autowired
     private PantryItemService pantryItemService;
+
+    @Autowired
+    private IngredientService ingredientService;
 
     public Connection<PantryItem> search(
             String query,
@@ -58,6 +64,10 @@ public class PantryQuery extends PagingQuery {
                         .limit(getLimit(first))
                         .build());
         return new OffsetConnection<>(rs);
+    }
+
+    public Collection<Ingredient> bulkIngredients(Collection<Long> ids) {
+        return ingredientService.bulkIngredients(ids);
     }
 
     public Iterable<PantryItem> updatedSince(Long cutoff) {

--- a/src/main/java/com/brennaswitzer/cookbook/services/IngredientService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/IngredientService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -79,6 +80,13 @@ public class IngredientService {
             results.addAll(findAllIngredientsByNameContaining(name));
         }
         return results;
+    }
+
+    public Collection<Ingredient> bulkIngredients(Collection<Long> ids) {
+        Collection<Ingredient> result = new ArrayList<>(ids.size());
+        result.addAll(pantryItemRepository.findAllById(ids));
+        result.addAll(recipeRepository.findAllById(ids));
+        return result;
     }
 
 }

--- a/src/main/resources/graphqls/library.graphqls
+++ b/src/main/resources/graphqls/library.graphqls
@@ -36,6 +36,13 @@ type LibraryQuery {
         after: Cursor = null
     ): RecipeConnection!
 
+    """Retrieve ingredients in bulk, regardless of type. Invalid IDs will be
+    silently ignored, and no result returned for them. Duplicate IDs will only
+    have a single result returned. The order of results is unspecified.
+    Identical to the query of the same name in 'pantry'.
+    """
+    bulkIngredients(ids: [ID!]): [Ingredient!]!
+
     """Retrieve a single recipe by its ID. Authenticated users can request any
     recipe. Anonymous users must supply the recipe's secret.
     """

--- a/src/main/resources/graphqls/pantry.graphqls
+++ b/src/main/resources/graphqls/pantry.graphqls
@@ -34,6 +34,13 @@ type PantryQuery {
         after: Cursor = null
     ): PantryItemConnection!
 
+    """Retrieve ingredients in bulk, regardless of type. Invalid IDs will be
+    silently ignored, and no result returned for them. Duplicate IDs will only
+    have a single result returned. The order of results is unspecified.
+    Identical to the query of the same name in 'pantry'.
+    """
+    bulkIngredients(ids: [ID!]): [Ingredient!]!
+
     updatedSince(cutoff: Long!): [PantryItem!]!
 }
 


### PR DESCRIPTION
The query behaves like the `bulk-ingredients` endpoint, returning a heterogeneous collection of `Ingredients`. Ingredients don't have their own slice of the GraphQL Query, so opted to put equivalent fields on both sides.