### PR TITLE
set up CDS for the prod image

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,9 @@ spring:
         jdbc:
           lob:
             non_contextual_creation: true
+        # Hibernate will indicate this isn't needed, but it's used earlier by
+        # Spring Data's JPA bootstrapping when there isn't a database available.
+        dialect: org.hibernate.dialect.PostgreSQLDialect
     open-in-view: true # the default; just suppress the warning
   security:
     oauth2:


### PR DESCRIPTION
Setting up [CDS](https://docs.spring.io/spring-framework/reference/integration/cds.html) adds an extra ~130MB layer to the image, but reduces startup time by about 50% on my local. Depending on how you ask, it either makes no difference to memory consumption or reduces it slightly. We'll see how GCP measures when it's deployed. :)

The Temurin I have didn't come with the system archive, but the base image has it. So didn't regen it for our image like I did locally.