### PR TITLE
don't cancel calendar events upon item delete

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/config/AppProperties.java
+++ b/src/main/java/com/brennaswitzer/cookbook/config/AppProperties.java
@@ -15,6 +15,11 @@ public class AppProperties {
     private String publicUrl;
     private long maxProxySize = 1024 * 1024 * 2;
 
+    /**
+     * Items untouched in the trash for this many days will be hard-deleted.
+     */
+    private int daysInTrashBin = 30;
+
     private final Auth auth = new Auth();
     private final OAuth2 oauth2 = new OAuth2();
     private final AWSProperties aws = new AWSProperties();

--- a/src/main/java/com/brennaswitzer/cookbook/config/CalendarProperties.java
+++ b/src/main/java/com/brennaswitzer/cookbook/config/CalendarProperties.java
@@ -11,4 +11,10 @@ public class CalendarProperties {
 
     private boolean validate;
 
+    /**
+     * Items deleted within this many hours of creation will be marked canceled,
+     * under assumption they were tentatively added and then discarded.
+     */
+    private int hoursDeletedWithinToCancel = 6;
+
 }

--- a/src/main/java/com/brennaswitzer/cookbook/services/EmptyTrashBins.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/EmptyTrashBins.java
@@ -1,5 +1,6 @@
 package com.brennaswitzer.cookbook.services;
 
+import com.brennaswitzer.cookbook.config.AppProperties;
 import com.brennaswitzer.cookbook.repositories.PlanItemRepository;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -18,11 +19,16 @@ import java.time.temporal.ChronoUnit;
 public class EmptyTrashBins {
 
     @Autowired
+    private AppProperties appProperties;
+
+    @Autowired
     private PlanItemRepository planItemRepository;
 
     @Scheduled(cron = "${random.int[60]} ${random.int[60]} * * * *")
     public void emptyTrashBins() {
-        val cutoff = Instant.now().minus(30, ChronoUnit.DAYS);
+        val cutoff = Instant.now()
+                .minus(appProperties.getDaysInTrashBin(),
+                       ChronoUnit.DAYS);
         var watch = new StopWatch();
         watch.start();
         val n = planItemRepository.deleteByUpdatedAtBeforeAndTrashBinIsNotNull(cutoff);


### PR DESCRIPTION
When an item is deleted within a dated bucket, don't cancel its calendar event until it has been in the trash a while. Unless it was deleted soon after creation, implying it was tentatively planned and then rejected.

This keeps the calendar projection of a plan intact for "a while", even as planned recipes are completed (or deleted) over the duration of executing the plan. The "while" lasts until the plan's buckets are updated/reset, capped at two weeks. 