### PR TITLE
Sections

### DIFF
--- a/sections.md
+++ b/sections.md
@@ -36,17 +36,21 @@ contextual viewpoints in the cook's mind. It's also the reason for all the itali
 
 ## GraphQL Schema
 
-1. _By reference_ sections are mutated via `IngredientInfo.ingredients` (as today).
-1. _By reference_ sections are queried via `Recipe.subrecipes` and/or `Recipe.ingredients` (as today).
-1. _Owned_ sections will be manipulated via extending `IngredientRefInfo`. The section's title and directions can reuse
-   `raw` and `preparation`. Two new fields will be added:
-    1. `ingredients: [IngredientRefInfo!]`, and
-    1. `labels: [String!]`.
-1. _Owned_ sections will be queried directly via a new `LibraryQuery.sections` field, and indirectly extending
-   `IngredientRef` analogous to above.
+1. Sections (_owned_ or _by reference_) are recipes; they can always be retrieved via `LibraryQuery.getRecipeById`and
+   `bulkIngredients`.
+1. _Owned_ sections will not be returned from `LibraryQuery.recipes` or `.suggestRecipesToCook`.
+1. Create a `LibrarySearch` input type with `LibraryQuery.recipes`'s params and accept that instead.
 
-Since sections (_owned_ or _by reference_) are recipes, they can always be retrieved via `LibraryQuery.getRecipeById`
-and `bulkIngredients`. _Owned_ sections will not be returned from `LibraryQuery.recipes` or `.suggestRecipesToCook`.
+1. Add a new `Section` type, sharing `id`, `name`, `direction`, `ingredients`, and `labels` with `Recipe`, plus a
+   `sectionOf: ID`.
+1. Add a new `sections: [Section!]!` to `Recipe`.
+1. Add a new `LibraryQuery.sections` field which also accepts `LibrarySearch` and only returns _owned_ sections
+   (as a new `SectionConnection` and friends).
+
+1. Add a new `SectionInfo` input type, sharing `id`, `name`, `direction`, `ingredients`, and `labels` with
+   `IngredientInfo`. _Owned_ sections will always have the data fields populated, as well as `id` once persistent. _By
+   reference_ sections will only ever have `id`.
+1. Add a new `sections: [SectionInfo!]` to `IngredientInfo`.
 
 ## Library
 

--- a/sections.md
+++ b/sections.md
@@ -97,6 +97,10 @@ contextual viewpoints in the cook's mind. It's also the reason for all the itali
 1. **FUTURE:** make the existing buttons into combo buttons which allow targeting a section, instead of the top-level
    recipe, if any sections exist.
 
+### Cook This!
+
+**FUTURE**
+
 ## Planner
 
 _Owned_ sections shouldn't have a "Cook" button.

--- a/sections.md
+++ b/sections.md
@@ -1,0 +1,142 @@
+# Sections
+
+A _section_ is a "partial recipe" which doesn't stand on its own. For example, you might have frosting as a
+section of a german chocolate cake recipe in your library. On the other hand, you might consider buttercream icing to be
+a recipe itself, only loosely associated with various other recipes.
+
+This distinction is entirely in the mind of the cook, and varies contextually. Continuing the example, buttercream
+"becomes" a section of the cupcake recipe you're planning Clara's birthday party this weekend. When you're making the
+cupcakes, the icing is a section of the cupcakes recipe, even though they're separate in your library.
+
+## Entity Model
+
+Sections are stored as recipes, with "section-ness" represented implicitly. _Owned_ sections (frosting) are
+"part of" their _owning_ recipe (german chocolate cake). Recipes (buttercream icing) may be _by reference_ sections of
+other recipes (cupcakes). An _owned_ section may also be the referent of _by reference_ sections (reuse german chocolate
+cake's frosting for cupcakes, without promoting frosting to a top-level recipe).
+
+1. Add a new `Recipe sectionOf;` field to the `Recipe` class, backed by a `ON DELETE RESTRICT` FK column in the
+   database.
+    1. The value indicates the recipe the section is _owned_ by.
+    1. Null means the recipe is not an _owned_ section.
+1. _By reference_ sections are normal entity associations (aka today's subrecipes).
+1. _Owned_ sections are as if composed into their _owning_ recipe.
+    1. When an _owned_ section is removed from a recipe, it is either:
+        1. deleted if not otherwise referenced, or
+        1. becomes _owned by_ an arbitrary referrer.
+    1. When a recipe is deleted, its _owned_ sections are removed first.
+1. An _owned_ section can be promoted to a top-level recipe, which converts the section to be _by reference_.
+1. A _by reference_ section can be demoted to an _owned_ section, as long as the referent is not already _owned_.
+
+This model yields two different definitions of "section": a recipe _owned by_ another (w/ `sectionOf` set), and a
+_reference_ from one recipe to another (an `IngredientRef` referring to a `Recipe`). This mirrors the two different
+contextual viewpoints in the cook's mind. It's also the reason for all the italics.
+
+## GraphQL Schema
+
+1. _By reference_ sections are mutated via `IngredientInfo.ingredients` (as today).
+1. _By reference_ sections are queried via `Recipe.subrecipes` and/or `Recipe.ingredients` (as today).
+1. _Owned_ sections will be manipulated via extending `IngredientRefInfo`. The section's title and directions can reuse
+   `raw` and `preparation`. Two new fields will be added:
+    1. `ingredients: [IngredientRefInfo!]`, and
+    1. `labels: [String!]`.
+1. _Owned_ sections will be queried directly via a new `LibraryQuery.sections` field, and indirectly extending
+   `IngredientRef` analogous to above.
+
+Since sections (_owned_ or _by reference_) are recipes, they can always be retrieved via `LibraryQuery.getRecipeById`
+and `bulkIngredients`. _Owned_ sections will not be returned from `LibraryQuery.recipes` or `.suggestRecipesToCook`.
+
+## Library
+
+### Search
+
+1. Exclude _owned_ sections from search results.
+1. Exclude _owned_ sections from recommendations.
+
+### Recipe Display
+
+1. _Owned_ sections participate in scaling, while _by reference_ sections do not.
+1. Sections with non-blank description float to the top w/ collapse as subrecipes do today.
+1. Sections with no description fall to the bottom of the ingredient list, title as subheading.
+
+### Recipe Form
+
+1. New "Add Section" button, to either:
+    1. create a blank _owned_ section, or
+    1. search for _owned_ sections (not all recipes) to include _by reference_.
+        1. This should probably have a toggle to search for all recipes, not just sections.
+1. _Owned_ sections contain title, ingredients, directions, and labels.
+    1. Title is required and gets defaulted to "MOAR Goober Whosit" or something.
+    1. Ingredients are optional, with a blank ElEdit row visible to start.
+        1. Cannot have _owned_ subsections, but can have _by reference_ subsections.
+    1. Directions and labels are optional, and should start collapsed if empty (with an icon to toggle visibility).
+1. _By reference_ sections:
+    1. are read only,
+    1. show a link to their top-level recipe, which is the section itself if not _owned_, and
+    1. can be one-click-replaced by a new _owned_ section of the current recipe, duplicating the underlying recipe, as
+       long as it doesn't have _owned_ sections.
+1. Adding a recipe as an ingredient creates a _by reference_ section (as today).
+    1. Recog suggestions (for ElEdit) exclude sections (like search results).
+1. Non-section ingredients can be dragged between _owned_ sections and/or the top-level recipe.
+1. Sections can be reordered, separate from reordering their ingredients. On the form, they don't float/fall.
+1. Sections can be removed from the recipe.
+1. _Owned_ sections have a "Uses" button, if any other recipe includes them _by reference_, which opens a dialog to
+   enumerate referrers. Should all sections?
+
+### Textract
+
+1. **FUTURE:** New "New Section" action button, which will create a new (name-defaulted) section and add the selected
+   text
+   as its
+   ingredients.
+1. **FUTURE:** make the existing buttons into combo buttons which allow targeting a section, instead of the top-level
+   recipe, if any sections exist.
+
+## Planner
+
+No special handling.
+
+### Cook Recipe or Bucket
+
+1. Remove ingredient scaling UI.
+1. Sections with non-blank description float to the top w/ collapse as subrecipes do today.
+1. Sections with no description fall to the bottom of the ingredient list, title as subheading.
+1. Hide "I Cooked It!" and "Open Library Recipe" for
+    1. _owned_ sections if the top-level recipe is also visible, and
+    1. all sections without a description.
+
+## Shopping
+
+No special handling.
+
+**FUTURE:** Adjust the attribution breadcrumbs, so section names come after the top-level recipe? Using sugar for
+the baking example:
+
+* sugar (10 c)
+    * 1 c sugar<br>German Chocolate Cake / Our Week
+    * 2 c sugar<br>Buttercream Icing / Cupcakes / Clara's Birthday / Our Week
+    * 3 c sugar<br>Cupcakes / Clara's Birthday / Our Week
+    * 4 c sugar<br>Frosting / German Chocolate Cake / Our Week
+
+I believe the frosting attribution would be better as "German Chocolate Cake - Frosting / Our Week". This gets awkward
+with Clara's cupcakes, as the same rule would yield "Cupcakes - Buttercream Icing / Clara's Birthday / Our Week" for the
+icing (reasonable) and "Clara's Birthday - Cupcakes / Our Week" for the cupcakes themselves (less reasonable). This
+might need to pass section ownership information from library to planner, so only frosting gets flipped around. Or maybe
+everything should always be top-down, period?
+
+Note that the "Our Week" breadcrumb is only visible if you're shopping multiple plans.
+
+## Plan Sidebar (and Calendar)
+
+1. **ASSUMPTION:** Sections usually stay with their recipe, so if you want to move them, having to open the full planner
+   is
+   reasonable for the reduced clutter of the sidebar. Hide planned recipes which:
+    1. are a section,
+    1. are a descendant of their aggregate, and
+    1. are in the same bucket as their aggregate, or not bucketed.
+
+## Pantry Item Admin
+
+1. The "Uses" popup needs to include the top-level recipe's name for _owned_ sections.
+    1. Include "and 7 other referrers"?
+    1. For _by reference_ sections too?

--- a/sections.md
+++ b/sections.md
@@ -13,12 +13,14 @@ cupcakes, the icing is a section of the cupcakes recipe, even though they're sep
 Sections are stored as recipes, with "section-ness" represented implicitly. _Owned_ sections (frosting) are
 "part of" their _owning_ recipe (german chocolate cake). Recipes (buttercream icing) may be _by reference_ sections of
 other recipes (cupcakes). An _owned_ section may also be the referent of _by reference_ sections (reuse german chocolate
-cake's frosting for cupcakes, without promoting frosting to a top-level recipe).
+cake's frosting for cupcakes, without 'promoting' frosting to a top-level recipe).
 
 1. Add a new `Recipe sectionOf;` field to the `Recipe` class, backed by a `ON DELETE RESTRICT` FK column in the
    database.
     1. The value indicates the recipe the section is _owned_ by.
     1. Null means the recipe is not an _owned_ section.
+1. Add a new `boolean section;` field to the `IngredientRef` class, for whether the ref is a section. Whether _owned_ or
+   _by reference_ is not differentiated.
 1. _By reference_ sections are normal entity associations (aka today's subrecipes).
 1. _Owned_ sections are as if composed into their _owning_ recipe.
     1. When an _owned_ section is removed from a recipe, it is either:
@@ -63,8 +65,9 @@ and `bulkIngredients`. _Owned_ sections will not be returned from `LibraryQuery.
 
 1. New "Add Section" button, to either:
     1. create a blank _owned_ section, or
-    1. search for _owned_ sections (not all recipes) to include _by reference_.
-        1. This should probably have a toggle to search for all recipes, not just sections.
+   1. search for _owned_ sections to include _by reference_.
+       1. This needs a toggle to search for recipes, instead of _owned_ sections. Or between _owned_ sections and
+          everything?
 1. _Owned_ sections contain title, ingredients, directions, and labels.
     1. Title is required and gets defaulted to "MOAR Goober Whosit" or something.
     1. Ingredients are optional, with a blank ElEdit row visible to start.
@@ -80,25 +83,23 @@ and `bulkIngredients`. _Owned_ sections will not be returned from `LibraryQuery.
 1. Non-section ingredients can be dragged between _owned_ sections and/or the top-level recipe.
 1. Sections can be reordered, separate from reordering their ingredients. On the form, they don't float/fall.
 1. Sections can be removed from the recipe.
-1. _Owned_ sections have a "Uses" button, if any other recipe includes them _by reference_, which opens a dialog to
+1. _Owned_ sections have a "Used By" button, if any other recipe includes them _by reference_, which opens a dialog to
    enumerate referrers. Should all sections?
 
 ### Textract
 
 1. **FUTURE:** New "New Section" action button, which will create a new (name-defaulted) section and add the selected
-   text
-   as its
-   ingredients.
+   text as its ingredients.
 1. **FUTURE:** make the existing buttons into combo buttons which allow targeting a section, instead of the top-level
    recipe, if any sections exist.
 
 ## Planner
 
-No special handling.
+_Owned_ sections shouldn't have a "Cook" button.
 
-### Cook Recipe or Bucket
+### Cook Planned Recipe or Bucket
 
-1. Remove ingredient scaling UI.
+1. Remove ingredient scaling UI; it's too late.
 1. Sections with non-blank description float to the top w/ collapse as subrecipes do today.
 1. Sections with no description fall to the bottom of the ingredient list, title as subheading.
 1. Hide "I Cooked It!" and "Open Library Recipe" for
@@ -124,13 +125,13 @@ icing (reasonable) and "Clara's Birthday - Cupcakes / Our Week" for the cupcakes
 might need to pass section ownership information from library to planner, so only frosting gets flipped around. Or maybe
 everything should always be top-down, period?
 
-Note that the "Our Week" breadcrumb is only visible if you're shopping multiple plans.
+Note that the "Our Week" breadcrumb is only visible if you're shopping multiple plans, and "Clara's Birthday" might be a
+bucket, not a plan item.
 
 ## Plan Sidebar (and Calendar)
 
 1. **ASSUMPTION:** Sections usually stay with their recipe, so if you want to move them, having to open the full planner
-   is
-   reasonable for the reduced clutter of the sidebar. Hide planned recipes which:
+   is reasonable for the reduced clutter of the sidebar. Hide planned recipes which:
     1. are a section,
     1. are a descendant of their aggregate, and
     1. are in the same bucket as their aggregate, or not bucketed.
@@ -140,3 +141,14 @@ Note that the "Our Week" breadcrumb is only visible if you're shopping multiple 
 1. The "Uses" popup needs to include the top-level recipe's name for _owned_ sections.
     1. Include "and 7 other referrers"?
     1. For _by reference_ sections too?
+
+## Discussion
+
+1. A quantity of an _owned_ section makes no sense; it's part of this recipe.
+1. A quantity of a _by reference_ section makes a lot of sense.
+    1. If you want to add buttercream icing to a recipe, you'd want to multiply across the buttercream recipe's yield.
+       E.g., if buttercream yields 4 c icing, but I only need 2 c for my recipe, I want "1/2 buttercream icing"
+1. A quantity of a _by reference_ section targeting an _owned_ section is ... uh
+    1. If you want to reuse german chocolate cake's coconut frosting for cupcakes, there's no yield for the frosting
+       alone. If the cake recipe makes two 9-inch layers, but your cupcake recipe makes 12, you need a _lot_ less
+       frosting... but there's no yield on a section to multiple across.

--- a/src/main/java/com/brennaswitzer/cookbook/domain/AggregateIngredient.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/AggregateIngredient.java
@@ -10,19 +10,19 @@ public interface AggregateIngredient {
 
     Collection<IngredientRef> getIngredients();
 
-    default void addIngredient(Ingredient ingredient) {
-        addIngredient(Quantity.ONE, ingredient, null);
+    default IngredientRef addIngredient(Ingredient ingredient) {
+        return addIngredient(Quantity.ONE, ingredient, null);
     }
 
-    default void addIngredient(Quantity quantity, Ingredient ingredient) {
-        addIngredient(quantity, ingredient, null);
+    default IngredientRef addIngredient(Quantity quantity, Ingredient ingredient) {
+        return addIngredient(quantity, ingredient, null);
     }
 
-    default void addIngredient(Ingredient ingredient, String preparation) {
-        addIngredient(Quantity.ONE, ingredient, preparation);
+    default IngredientRef addIngredient(Ingredient ingredient, String preparation) {
+        return addIngredient(Quantity.ONE, ingredient, preparation);
     }
 
-    void addIngredient(Quantity quantity, Ingredient ingredient, String preparation);
+    IngredientRef addIngredient(Quantity quantity, Ingredient ingredient, String preparation);
 
     /**
      * I return the PantryItem IngredientRefs for this Ingredient, including

--- a/src/main/java/com/brennaswitzer/cookbook/domain/IngredientRef.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/IngredientRef.java
@@ -25,6 +25,12 @@ public class IngredientRef implements MutableItem {
     @Column(name = "_order")
     private int _idx;
 
+    /**
+     * Does this ref represent a section?
+     */
+    @Column(name = "is_section")
+    private boolean section;
+
     private String raw;
 
     @Embedded

--- a/src/main/java/com/brennaswitzer/cookbook/domain/IngredientRef.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/IngredientRef.java
@@ -26,7 +26,7 @@ public class IngredientRef implements MutableItem {
     private int _idx;
 
     /**
-     * Does this ref represent a section?
+     * Whether this ref represents a section (owned or by reference).
      */
     @Column(name = "is_section")
     private boolean section;

--- a/src/main/java/com/brennaswitzer/cookbook/domain/Recipe.java
+++ b/src/main/java/com/brennaswitzer/cookbook/domain/Recipe.java
@@ -246,8 +246,8 @@ public class Recipe extends Ingredient implements AggregateIngredient, Owned {
             section.clearSectionOf();
             Iterator<IngredientRef> refItr = ingredients.iterator();
             while (refItr.hasNext()) {
-                IngredientRef r = refItr.next();
-                if (r.isSection() && section.equals(r.getIngredient())) {
+                IngredientRef ref = refItr.next();
+                if (ref.isSection() && section.equals(ref.getIngredient())) {
                     refItr.remove();
                     break;
                 }

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/GqlSearch.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/GqlSearch.java
@@ -2,9 +2,14 @@ package com.brennaswitzer.cookbook.graphql;
 
 import com.brennaswitzer.cookbook.graphql.model.OffsetConnectionCursor;
 
-abstract class PagingQuery {
+public interface GqlSearch {
 
-    protected int getOffset(OffsetConnectionCursor after) {
+    int getFirst();
+
+    OffsetConnectionCursor getAfter();
+
+    default int getOffset() {
+        OffsetConnectionCursor after = getAfter();
         return after == null
                 ? 0
                 : after.getOffset() + 1;

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/model/Section.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/model/Section.java
@@ -1,0 +1,56 @@
+package com.brennaswitzer.cookbook.graphql.model;
+
+import com.brennaswitzer.cookbook.domain.IngredientRef;
+import com.brennaswitzer.cookbook.domain.Label;
+import com.brennaswitzer.cookbook.domain.Recipe;
+import org.hibernate.Hibernate;
+
+import java.util.List;
+import java.util.Set;
+
+public class Section {
+
+    private final Recipe delegate;
+
+    public Section(Recipe delegate) {
+        this.delegate = delegate;
+    }
+
+    public static boolean isSection(IngredientRef ref) {
+        return ref.isSection()
+               && ref.hasIngredient()
+               && Hibernate.unproxy(ref.getIngredient()) instanceof Recipe;
+    }
+
+    public static Section from(IngredientRef ref) {
+        if (!isSection(ref)) {
+            throw new IllegalArgumentException("Ref is not a section: " + ref);
+        }
+        return new Section((Recipe) Hibernate.unproxy(ref.getIngredient()));
+    }
+
+    public Recipe getSectionOf() {
+        return delegate.getSectionOf();
+    }
+
+    public String getDirections() {
+        return delegate.getDirections();
+    }
+
+    public List<IngredientRef> getIngredients() {
+        return delegate.getIngredients();
+    }
+
+    public String getName() {
+        return delegate.getName();
+    }
+
+    public Set<Label> getLabels() {
+        return delegate.getLabels();
+    }
+
+    public Long getId() {
+        return delegate.getId();
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/resolvers/SectionResolver.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/resolvers/SectionResolver.java
@@ -1,0 +1,24 @@
+package com.brennaswitzer.cookbook.graphql.resolvers;
+
+import com.brennaswitzer.cookbook.graphql.model.Section;
+import com.brennaswitzer.cookbook.mapper.LabelMapper;
+import graphql.kickstart.tools.GraphQLResolver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class SectionResolver implements GraphQLResolver<Section> {
+
+    @Autowired
+    private LabelMapper labelMapper;
+
+    public List<String> labels(Section section) {
+        return section.getLabels()
+                .stream()
+                .map(labelMapper::labelToString)
+                .toList();
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/graphql/support/Info2Recipe.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/support/Info2Recipe.java
@@ -1,0 +1,176 @@
+package com.brennaswitzer.cookbook.graphql.support;
+
+import com.brennaswitzer.cookbook.domain.Identified;
+import com.brennaswitzer.cookbook.domain.Ingredient;
+import com.brennaswitzer.cookbook.domain.IngredientRef;
+import com.brennaswitzer.cookbook.domain.PantryItem;
+import com.brennaswitzer.cookbook.domain.Recipe;
+import com.brennaswitzer.cookbook.domain.User;
+import com.brennaswitzer.cookbook.payload.CoreRecipeInfo;
+import com.brennaswitzer.cookbook.payload.IngredientInfo;
+import com.brennaswitzer.cookbook.payload.IngredientRefInfo;
+import com.brennaswitzer.cookbook.payload.SectionInfo;
+import com.brennaswitzer.cookbook.security.UserPrincipal;
+import com.brennaswitzer.cookbook.services.ItemService;
+import com.brennaswitzer.cookbook.services.LabelService;
+import com.brennaswitzer.cookbook.services.RecipeService;
+import jakarta.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class Info2Recipe {
+
+    @Autowired
+    private RecipeService recipeService;
+    @Autowired
+    private ItemService itemService;
+    @Autowired
+    private LabelService labelService;
+    @Autowired
+    private EntityManager entityManager;
+
+    public Recipe convert(UserPrincipal owner,
+                          IngredientInfo info) {
+        return convert(owner, info, false);
+    }
+
+    public Recipe convert(UserPrincipal owner,
+                          IngredientInfo info,
+                          boolean cookThis) {
+        return new Convert(cookThis,
+                           entityManager.find(User.class,
+                                              owner.getId()))
+                .toRecipe(info);
+    }
+
+    private class Convert {
+
+        private final boolean cookThis;
+        private final User owner;
+
+        private Convert(boolean cookThis, User owner) {
+            this.cookThis = cookThis;
+            this.owner = owner;
+        }
+
+        public Recipe toRecipe(IngredientInfo info) {
+            Recipe r;
+            if (info.getId() == null) {
+                r = newRecipe();
+            } else {
+                r = loadRecipe(info);
+                if (!r.getOwner().equals(owner)) {
+                    throw new AccessDeniedException("You can only modify your own recipes.");
+                }
+                // remove no-longer-present owned sections
+                Collection<Recipe> toRemove;
+                if (info.hasSections()) {
+                    Set<Long> idsToRetain = info.getSections()
+                            .stream()
+                            .map(SectionInfo::getId)
+                            .collect(Collectors.toSet());
+                    toRemove = r.getOwnedSections()
+                            .stream()
+                            .filter(s -> s.getId() != null)
+                            .filter(s -> !idsToRetain.contains(s.getId()))
+                            .toList();
+                } else {
+                    // copy the collection to consume while iterating
+                    toRemove = List.copyOf(r.getOwnedSections());
+                }
+                toRemove.forEach(recipeService::removeOwnedSection);
+
+            }
+            setCoreInfo(info, r);
+            if (info.hasSections()) {
+                for (var s : info.getSections()) {
+                    toRecipeUnder(s, r);
+                }
+            }
+            r.setExternalUrl(info.getExternalUrl());
+            r.setYield(info.getYield());
+            r.setTotalTime(info.getTotalTime());
+            r.setCalories(info.getCalories());
+            // photo is NOT copied, as the S3 object needs to move too
+            float[] photoFocus = info.getPhotoFocus();
+            if (photoFocus != null && photoFocus.length == 2) {
+                r.getPhoto(true).setFocusArray(photoFocus);
+            }
+            return r;
+        }
+
+        private void setCoreInfo(CoreRecipeInfo info, Recipe r) {
+            r.setName(info.getName());
+            r.setDirections(info.getDirections());
+            if (info.hasIngredients()) {
+                r.setIngredients(info.getIngredients()
+                                         .stream()
+                                         .map(this::toIngredientRef)
+                                         .collect(Collectors.toList()));
+                if (cookThis) {
+                    r.getIngredients().forEach(itemService::autoRecognize);
+                }
+            }
+            labelService.updateLabels(r, info.getLabels());
+        }
+
+        private IngredientRef toIngredientRef(IngredientRefInfo info) {
+            IngredientRef ref = new IngredientRef();
+            ref.setRaw(info.getRaw());
+            if (info.hasQuantity()) {
+                ref.setQuantity(info.extractQuantity(entityManager));
+            }
+            ref.setPreparation(info.getPreparation());
+            if (info.hasIngredientId()) {
+                // don't know what type it is...
+                ref.setIngredient(entityManager.find(Ingredient.class,
+                                                     info.getIngredientId()));
+            } else if (info.hasIngredient()) {
+                PantryItem it = new PantryItem(info.getIngredient());
+                entityManager.persist(it);
+                ref.setIngredient(it);
+            }
+            return ref;
+        }
+
+        private void toRecipeUnder(SectionInfo info,
+                                   Recipe parent) {
+            Recipe s;
+            if (info.getId() == null) {
+                s = newRecipe();
+                parent.addOwnedSection(s);
+            } else {
+                // cross-user references are fine
+                s = loadRecipe(info);
+                parent.addIngredient(s)
+                        .setSection(true);
+                if (!s.isOwnedSection() || !s.getSectionOf().equals(parent)) {
+                    // not owned, just a reference
+                    return;
+                }
+            }
+            setCoreInfo(info, s);
+        }
+
+        private Recipe newRecipe() {
+            Recipe r = new Recipe();
+            r.setOwner(owner);
+            entityManager.persist(r);
+            return r;
+        }
+
+        private Recipe loadRecipe(Identified info) {
+            return entityManager.find(Recipe.class,
+                                      info.getId());
+        }
+
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/payload/CoreRecipeInfo.java
+++ b/src/main/java/com/brennaswitzer/cookbook/payload/CoreRecipeInfo.java
@@ -1,0 +1,30 @@
+package com.brennaswitzer.cookbook.payload;
+
+import com.brennaswitzer.cookbook.domain.Identified;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@Setter
+public class CoreRecipeInfo implements Identified {
+
+    private Long id;
+    private String name;
+    private String directions;
+    private List<IngredientRefInfo> ingredients;
+    private List<String> labels;
+
+    public List<String> getLabels() {
+        return labels == null
+                ? Collections.emptyList()
+                : labels;
+    }
+
+    public boolean hasIngredients() {
+        return getIngredients() != null && !getIngredients().isEmpty();
+    }
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/payload/IngredientInfo.java
+++ b/src/main/java/com/brennaswitzer/cookbook/payload/IngredientInfo.java
@@ -6,27 +6,18 @@ import jakarta.persistence.EntityManager;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
 @Setter
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class IngredientInfo {
+public class IngredientInfo extends CoreRecipeInfo {
 
-    @Deprecated
-    public static class Ref extends IngredientRefInfo {
-    }
-
-    private Long id;
     private String type;
-    private String name;
     private Integer storeOrder;
     private String externalUrl;
-    private String directions;
-    private List<IngredientRefInfo> ingredients;
-    private List<String> labels;
+    private List<SectionInfo> sections;
     private Long ownerId;
     private Integer yield;
     private Integer calories;
@@ -34,12 +25,6 @@ public class IngredientInfo {
     private String photo;
     private float[] photoFocus;
     private Boolean cookThis;
-
-    public List<String> getLabels() {
-        return labels == null
-                ? Collections.emptyList()
-                : labels;
-    }
 
     public boolean isCookThis() {
         return cookThis != null && cookThis;
@@ -55,7 +40,7 @@ public class IngredientInfo {
         r.setYield(getYield());
         r.setTotalTime(getTotalTime());
         r.setCalories(getCalories());
-        if (getIngredients() != null) {
+        if (hasIngredients()) {
             r.setIngredients(getIngredients()
                     .stream()
                     .map(ref -> ref.asIngredientRef(em))
@@ -66,6 +51,10 @@ public class IngredientInfo {
             r.getPhoto(true).setFocusArray(photoFocus);
         }
         return r;
+    }
+
+    public boolean hasSections() {
+        return getSections() != null && !getSections().isEmpty();
     }
 
 }

--- a/src/main/java/com/brennaswitzer/cookbook/payload/SectionInfo.java
+++ b/src/main/java/com/brennaswitzer/cookbook/payload/SectionInfo.java
@@ -1,0 +1,8 @@
+package com.brennaswitzer.cookbook.payload;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class SectionInfo extends CoreRecipeInfo {
+
+}

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/PlannedRecipeHistoryRepository.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/PlannedRecipeHistoryRepository.java
@@ -19,12 +19,14 @@ public interface PlannedRecipeHistoryRepository extends BaseEntityRepository<Pla
      * ago will contribute a quarter as much as today.
      */
     @Query(value = """
-                   SELECT recipe_id
-                     FROM planned_recipe_history
-                    WHERE owner_id = :userId
-                      AND status_id = 100 -- completed
-                    GROUP BY recipe_id
-                    ORDER BY SUM(EXP(LN(0.5) / 60 * (CURRENT_DATE - CAST(done_at AS DATE))) * COALESCE(rating, 3)) DESC
+                   SELECT h.recipe_id
+                     FROM planned_recipe_history h
+                              JOIN ingredient i ON h.recipe_id = i.id
+                    WHERE h.owner_id = :userId
+                      AND h.status_id = 100 -- completed
+                      AND i.section_of_id IS NULL -- not an owned section
+                    GROUP BY h.recipe_id
+                    ORDER BY SUM(EXP(LN(0.5) / 60 * (CURRENT_DATE - CAST(h.done_at AS DATE))) * COALESCE(h.rating, 3)) DESC
                            , 1
                     LIMIT :limit
                    OFFSET :offset

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/RecipeRepository.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/RecipeRepository.java
@@ -16,7 +16,7 @@ public interface RecipeRepository extends BaseEntityRepository<Recipe>, RecipeSe
 
     List<Recipe> findByOwnerAndNameIgnoreCaseOrderById(User owner, String name);
 
-    List<Recipe> findAllByOwnerAndNameIgnoreCaseContainingOrderById(User owner, String name);
+    List<Recipe> findAllByOwnerAndNameIgnoreCaseContainingAndSectionOfIsNullOrderById(User owner, String name);
 
     List<Recipe> findByIdIn(Collection<Long> ids);
 

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/impl/LibrarySearchRequest.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/impl/LibrarySearchRequest.java
@@ -9,16 +9,22 @@ import org.springframework.data.domain.Sort;
 import java.util.Set;
 
 @Value
-@Builder
+@Builder(toBuilder = true)
 public class LibrarySearchRequest implements SearchRequest {
 
     LibrarySearchScope scope;
+    LibrarySearchType type;
     User user;
     String filter;
     Set<Long> ingredientIds;
     int offset;
     int limit;
     Sort sort;
+
+    public LibrarySearchType getType() {
+        if (type != null) return type;
+        return LibrarySearchType.TOP_LEVEL_RECIPE;
+    }
 
     public boolean isFiltered() {
         return filter != null && !filter.isBlank();

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/impl/LibrarySearchType.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/impl/LibrarySearchType.java
@@ -1,0 +1,6 @@
+package com.brennaswitzer.cookbook.repositories.impl;
+
+public enum LibrarySearchType {
+    TOP_LEVEL_RECIPE,
+    OWNED_SECTION,
+}

--- a/src/main/java/com/brennaswitzer/cookbook/services/IngredientService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/IngredientService.java
@@ -44,7 +44,9 @@ public class IngredientService {
         List<PantryItem> pantryItems = pantryItemRepository.findAllByNameIgnoreCaseContainingOrderById(unpluralized);
         List<Ingredient> result = new ArrayList<>(pantryItems);
         User user = principalAccess.getUser();
-        List<Recipe> recipes = recipeRepository.findAllByOwnerAndNameIgnoreCaseContainingOrderById(user, unpluralized);
+        List<Recipe> recipes = recipeRepository.findAllByOwnerAndNameIgnoreCaseContainingAndSectionOfIsNullOrderById(
+                user,
+                unpluralized);
         result.addAll(recipes);
         return result;
     }

--- a/src/main/java/com/brennaswitzer/cookbook/services/RecipeService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/RecipeService.java
@@ -244,19 +244,34 @@ public class RecipeService {
                 scale);
     }
 
+    /**
+     * @deprecated prefer {@link #searchLibrary}
+     */
+    @Deprecated
     public SearchResponse<Recipe> searchRecipes(LibrarySearchScope scope,
                                                 String filter,
                                                 Set<Long> ingredientIds,
                                                 int offset,
                                                 int limit) {
-        return recipeRepository.searchRecipes(
+        return searchInternal(
                 LibrarySearchRequest.builder()
-                        .user(principalAccess.getUser())
                         .scope(scope)
                         .filter(filter)
                         .ingredientIds(ingredientIds)
                         .offset(offset)
-                        .limit(limit)
+                        .limit(limit));
+    }
+
+    public SearchResponse<Recipe> searchLibrary(
+            LibrarySearchRequest req) {
+        return searchInternal(req.toBuilder());
+    }
+
+    private SearchResponse<Recipe> searchInternal(
+            LibrarySearchRequest.LibrarySearchRequestBuilder reqBuilder) {
+        return recipeRepository.searchRecipes(
+                reqBuilder
+                        .user(principalAccess.getUser())
                         .build());
     }
 

--- a/src/main/java/com/brennaswitzer/cookbook/services/RecipeService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/RecipeService.java
@@ -116,8 +116,11 @@ public class RecipeService {
         Recipe recipe = getMyRecipe(id);
         removePhotoInternal(recipe);
         planService.severLibraryLinks(recipe);
-        recipe.getOwnedSections()
-                .forEach(this::removeOwnedSection);
+        while (!recipe.getOwnedSections().isEmpty()) {
+            removeOwnedSection(recipe.getOwnedSections()
+                                       .iterator()
+                                       .next());
+        }
         recipeRepository.delete(recipe);
         return recipe;
     }

--- a/src/main/resources/db/changelog/gobrennas-2025.sql
+++ b/src/main/resources/db/changelog/gobrennas-2025.sql
@@ -111,3 +111,21 @@ ALTER TABLE user_device
 UPDATE user_device
    SET last_ensured_at = created_at
  WHERE last_ensured_at = NOW();
+
+
+--changeset barneyb:recipe-sections
+ALTER TABLE ingredient
+    ADD section_of_id BIGINT NULL;
+
+CREATE INDEX idx_ingredient_section_of ON ingredient (section_of_id);
+
+ALTER TABLE ingredient
+    ADD CONSTRAINT fk_ingredient_section_of
+        FOREIGN KEY (section_of_id)
+            REFERENCES ingredient (id)
+            ON DELETE RESTRICT;
+
+ALTER TABLE recipe_ingredients
+    ADD is_section BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX idx_ingredient_recipe ON recipe_ingredients (ingredient_id, recipe_id);

--- a/src/main/resources/graphqls/library.graphqls
+++ b/src/main/resources/graphqls/library.graphqls
@@ -7,32 +7,65 @@ enum LibrarySearchScope {
     EVERYONE
 }
 
+input LibrarySearch {
+    """The scope to search within, 'only mine' by default.
+    """
+    scope: LibrarySearchScope! = MINE
+    """The textual query to filter results by. Can include simple words, as
+    well as quoted phrases.
+    """
+    query: String! = ""
+    """Only return results which include at least one of these ingredients.
+    """
+    ingredients: [ID!]! = []
+    """How many results to return. If not specified, 10 will be returned.
+    """
+    first: NonNegativeInt! = 10
+    """Cursor to find results after. Omit to retrieve the first page.
+    """
+    after: Cursor = null
+}
+
+input SuggestionSearch {
+    """How many results to return. If not specified, 5 will be returned.
+    """
+    first: NonNegativeInt! = 5
+    """Cursor to find results after. Omit to retrieve the first page.
+    """
+    after: Cursor = null
+}
+
 type LibraryQuery {
     """Search the recipe library.
     """
     recipes(
-        """The scope to search for recipes within.
+        search: LibrarySearch
+        """The scope to search for recipes within. Prefer `search.scope`.
         """
         scope: LibrarySearchScope! = MINE
         """The textual query to filter results by. Can include simple words, as
-        well as quoted phrases.
+        well as quoted phrases. Prefer `search.query`.
         """
         query: String! = ""
-        """Ingredient(s) to include. Missing/empty means "all".
+        """Ingredient(s) to include. Missing/empty means "all". Prefer
+        `search.ingredients`.
         """
         ingredients: [ID!]! = []
         """How many recipes to return in the connection. If not specified, 10
-        will be returned.
+        will be returned.  Prefer `search.first`.
         """
         first: NonNegativeInt! = 10
         """Cursor to find results after. This should be omitted to retrieve the
-        first page.
+        first page. Prefer `search.after`.
         """
         after: Cursor = null
     ): RecipeConnection!
 
     suggestRecipesToCook(
+        search: SuggestionSearch
+        "Prefer `search.first`."
         first: NonNegativeInt! = 5
+        "Prefer `search.after`."
         after: Cursor = null
     ): RecipeConnection!
 

--- a/src/main/resources/graphqls/library.graphqls
+++ b/src/main/resources/graphqls/library.graphqls
@@ -262,6 +262,7 @@ type UnitOfMeasure implements Node {
     id: ID!
     name: String!
 }
+
 enum Rating {
     ONE_STAR
     TWO_STARS
@@ -350,12 +351,14 @@ type RecipeHistoryMutation {
 }
 
 input IngredientInfo {
+    id: ID
     type: String!
     name: String!
     storeOrder: Int
     externalUrl: String
     directions: String
     ingredients: [IngredientRefInfo!]
+    sections: [SectionInfo!]
     labels: [String!]
     yield: Int
     calories: Int
@@ -369,8 +372,19 @@ input IngredientRefInfo {
     raw: String!
     quantity: Float
     units: String
-    uomId: Long
+    uomId: ID
     ingredient: String
-    ingredientId: Long
+    ingredientId: ID
     preparation: String
+}
+
+input SectionInfo {
+    """Id of the section, owned or by reference. Unsaved owned sections have
+    null. By reference sections will have no other fields populated.
+    """
+    id: ID
+    name: String
+    directions: String
+    ingredients: [IngredientRefInfo!]
+    labels: [String!]
 }

--- a/src/main/resources/graphqls/library.graphqls
+++ b/src/main/resources/graphqls/library.graphqls
@@ -15,7 +15,8 @@ input LibrarySearch {
     well as quoted phrases.
     """
     query: String! = ""
-    """Only return results which include at least one of these ingredients.
+    """Only return results which include at least one of these ingredients. An
+    empty list means "unconstrained".
     """
     ingredients: [ID!]! = []
     """How many results to return. If not specified, 10 will be returned.
@@ -47,8 +48,8 @@ type LibraryQuery {
         well as quoted phrases. Prefer `search.query`.
         """
         query: String! = ""
-        """Ingredient(s) to include. Missing/empty means "all". Prefer
-        `search.ingredients`.
+        """Only return results which include at least one of these ingredients.
+        An empty list means "unconstrained". Prefer `search.ingredients`.
         """
         ingredients: [ID!]! = []
         """How many recipes to return in the connection. If not specified, 10
@@ -60,6 +61,10 @@ type LibraryQuery {
         """
         after: Cursor = null
     ): RecipeConnection!
+
+    """Search for sections of recipes.
+    """
+    sections(search: LibrarySearch!): SectionConnection!
 
     suggestRecipesToCook(
         search: SuggestionSearch
@@ -153,6 +158,16 @@ type RecipeConnectionEdge {
     cursor: Cursor!
 }
 
+type SectionConnection {
+    edges: [SectionConnectionEdge!]!
+    pageInfo: PageInfo!
+}
+
+type SectionConnectionEdge {
+    node: Section!
+    cursor: Cursor!
+}
+
 interface Ingredient implements Node {
     id: ID!
     name: String!
@@ -171,13 +186,22 @@ type Recipe implements Node & Owned & Ingredient {
     name: String!
     externalUrl: String
     directions: String
+    """Ingredients which are part of the recipe. Ingredients and sections are
+    disjoint.
+    """
     ingredients(
         """Ingredient(s) to include. Missing/empty means "all".
         """
         ingredients: [ID!]! = []
     ): [IngredientRef!]!
+    """Sections of the recipe, owned or by reference. Use `sectionOf` if you
+    need to differentiate. Sections and ingredients are disjoint.
+    """
+    sections: [Section!]!
     """All subrecipes. Multiple layers of nested recipes are flattened, and the
-    contextual recipe is not included.
+    contextual recipe is not included. This does not include sections (owned or
+    unowned) of the contextual recipe, only recipe-as-ingredient, but sections
+    of those subrecipes _are_ included.
     """
     subrecipes: [Recipe!]!
     labels: [String!]
@@ -203,6 +227,18 @@ type Recipe implements Node & Owned & Ingredient {
         last: NonNegativeInt = 5
     ): [PlannedRecipeHistory!]!
     share: ShareInfo!
+}
+
+type Section implements Node {
+    id: ID!
+    """The recipe this section belongs to, if owned. When a top-level recipe is
+    used as a section, this will be null.
+    """
+    sectionOf: Recipe
+    name: String!
+    directions: String
+    ingredients: [IngredientRef!]!
+    labels: [String!]
 }
 
 type Photo {

--- a/src/main/resources/graphqls/pantry.graphqls
+++ b/src/main/resources/graphqls/pantry.graphqls
@@ -7,8 +7,37 @@ enum SortDir {
     DESC
 }
 
+input PantrySearch {
+    """Textual query to filter items by. The exact query operation performed
+    is unspecified, except that 'duplicates:12345' will return auto-detected
+    duplicates of the item with id '12345'. Exactly what "duplicate" means
+    is unspecified and subject to change, excepting that it will remain
+    consistent with results' "duplicateCount".
+    """
+    query: String
+    """Field to sort the result by. If omitted, the sort will be stable, but
+    is otherwise unspecified.
+    """
+    sortBy: String
+    """Direction to sort the result, ascending by default.
+    """
+    sortDir: SortDir = ASC
+    """How many items to return in the connection. If not specified, 25 will be
+    returned.
+    """
+    first: NonNegativeInt! = 25
+    """Cursor to find results after. This should be omitted to retrieve the
+    first page.
+    """
+    after: Cursor = null
+}
+
 type PantryQuery {
-    """Search available pantry items.
+    pantryItems(
+        search: PantrySearch!
+    ): PantryItemConnection!
+
+    """Search available pantry items. Prefer `pantryItems()`.
     """
     search(
         """Textual query to filter items by. The exact query operation performed

--- a/src/test/java/com/brennaswitzer/cookbook/domain/RecipeTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/domain/RecipeTest.java
@@ -7,8 +7,11 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RecipeTest {
 
@@ -61,6 +64,30 @@ public class RecipeTest {
         assertEquals("water", itr.next().getIngredient().getName());
         assertEquals("yeast", itr.next().getIngredient().getName());
         assertFalse(itr.hasNext());
+    }
+
+    @Test
+    void addOwnedSection() {
+        RecipeBox box = new RecipeBox();
+        box.pizza.addOwnedSection(box.pizzaCrust);
+        box.pizza.addOwnedSection(box.pizzaCrust); // a no-op
+
+        assertTrue(box.pizzaCrust.isOwnedSection());
+        assertEquals(box.pizza, box.pizzaCrust.getSectionOf());
+        assertEquals(List.of(box.pizzaCrust), box.pizza.getOwnedSections());
+    }
+
+    @Test
+    void removeOwnedSection() {
+        RecipeBox box = new RecipeBox();
+        assertThrows(RuntimeException.class,
+                     () -> box.pizza.removeOwnedSection(box.pizzaCrust));
+        box.pizza.addOwnedSection(box.pizzaCrust);
+        box.pizza.removeOwnedSection(box.pizzaCrust);
+
+        assertFalse(box.pizzaCrust.isOwnedSection());
+        assertNull(box.pizzaCrust.getSectionOf());
+        assertEquals(List.of(), box.pizza.getOwnedSections());
     }
 
 }

--- a/src/test/java/com/brennaswitzer/cookbook/graphql/support/Info2RecipeTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/graphql/support/Info2RecipeTest.java
@@ -1,0 +1,150 @@
+package com.brennaswitzer.cookbook.graphql.support;
+
+import com.brennaswitzer.cookbook.domain.BaseEntity;
+import com.brennaswitzer.cookbook.domain.Ingredient;
+import com.brennaswitzer.cookbook.domain.IngredientRef;
+import com.brennaswitzer.cookbook.domain.PantryItem;
+import com.brennaswitzer.cookbook.domain.Recipe;
+import com.brennaswitzer.cookbook.payload.IngredientInfo;
+import com.brennaswitzer.cookbook.security.UserPrincipal;
+import com.brennaswitzer.cookbook.services.LabelService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class Info2RecipeTest {
+
+    private static final long USER_ID = 123L;
+
+    @InjectMocks
+    private Info2Recipe converter;
+
+    @Mock
+    private LabelService labelService;
+    @Mock
+    private EntityManager entityManager;
+    @Mock
+    private UserPrincipal userPrincipal;
+
+    private IngredientInfo withSections;
+    private AtomicLong id_seq;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        when(userPrincipal.getId())
+                .thenReturn(USER_ID);
+        doAnswer(iom -> {
+            Class<? extends BaseEntity> clazz = iom.getArgument(0);
+            Long id = iom.getArgument(1);
+            if (Ingredient.class.equals(clazz)) {
+                clazz = id < 100
+                        ? Recipe.class
+                        : PantryItem.class;
+            }
+            BaseEntity it = clazz.newInstance();
+            it.setId(id);
+            if (it instanceof Ingredient ing) {
+                ing.setName("ing " + id);
+            }
+            return it;
+        })
+                .when(entityManager)
+                .find(any(), any());
+        id_seq = new AtomicLong(100000);
+        doAnswer(iom -> {
+            BaseEntity it = iom.getArgument(0);
+            it.setId(id_seq.incrementAndGet());
+            return null;
+        })
+                .when(entityManager)
+                .persist(any());
+
+        withSections = new ObjectMapper()
+                .readValue(getClass().getResourceAsStream("with_sections.json"),
+                           IngredientInfo.class);
+    }
+
+    @Test
+    void topLevel() {
+        Recipe recipe = converter.convert(userPrincipal,
+                                          withSections);
+
+        assertEquals("With Sections",
+                     recipe.getName());
+        assertEquals("First the flugel, then the booble",
+                     recipe.getDirections());
+        assertEquals(4 + 2,
+                     recipe.getIngredients().size());
+        // just the top-level recipe
+        verify(entityManager).persist(any(Recipe.class));
+        verify(labelService).updateLabels(recipe,
+                                          List.of("top-level"));
+    }
+
+    @Test
+    void unsavedSectionBecomesOwned() {
+        withSections.getSections().get(1).setId(null);
+        Recipe recipe = converter.convert(userPrincipal,
+                                          withSections);
+
+        assertEquals(1,
+                     recipe.getOwnedSections().size());
+        assertSame(recipe,
+                   recipe.getOwnedSections().iterator().next().getSectionOf());
+    }
+
+    @Test
+    void byReferenceSectionsDontUpdate() {
+        withSections.getSections().get(1).setId(null);
+        Recipe recipe = converter.convert(userPrincipal,
+                                          withSections);
+
+        List<IngredientRef> sections = recipe.getIngredients()
+                .stream()
+                .filter(IngredientRef::isSection)
+                .toList();
+        assertEquals(2,
+                     sections.size());
+        assertEquals(List.of("ing 48", "Italian Dressing"),
+                     sections.stream()
+                             .map(IngredientRef::getIngredient)
+                             .map(Ingredient::getName)
+                             .toList());
+    }
+
+    @Test
+    void saveOwnedSectionsLabels() {
+        withSections.getSections().get(1).setId(null);
+        Recipe recipe = converter.convert(userPrincipal,
+                                          withSections);
+
+        @SuppressWarnings("OptionalGetWithoutIsPresent")
+        Ingredient dressing = recipe.getIngredients()
+                .stream()
+                .filter(IngredientRef::isSection)
+                .skip(1)
+                .map(IngredientRef::getIngredient)
+                .findFirst()
+                .get();
+        verify(labelService).updateLabels(dressing,
+                                          List.of("section", "dressing"));
+    }
+
+}

--- a/src/test/java/com/brennaswitzer/cookbook/repositories/PostgresFullTextQueryConverterTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/repositories/PostgresFullTextQueryConverterTest.java
@@ -17,6 +17,7 @@ public class PostgresFullTextQueryConverterTest {
                         "chicken thighs"        , chicken <-> thighs
                         celery "chicken thighs" , celery:* | chicken <-> thighs
                         'a b' "c d" e 'f "g     , a <-> b | c <-> d | e:* | f:* | g:*
+                        a (!not | pipe & amp)  , a:* | not:* | pipe:* | amp:*
                         """)
     public void filterConversion(String input, String expected) {
         String actual = new PostgresFullTextQueryConverter()

--- a/src/test/java/com/brennaswitzer/cookbook/repositories/RecipeSearchRepositoryImplTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/repositories/RecipeSearchRepositoryImplTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -60,7 +61,8 @@ public class RecipeSearchRepositoryImplTest {
         doReturn(query)
                 .when(entityManager)
                 .createNativeQuery(any(), eq(Recipe.class));
-        doReturn(2L)
+        // only used when no query is provided.
+        lenient().doReturn(2L)
                 .when(user)
                 .getId();
     }
@@ -121,8 +123,6 @@ public class RecipeSearchRepositoryImplTest {
         verify(entityManager)
                 .createNativeQuery(sqlCaptor.capture(), eq(Recipe.class));
         verify(query)
-                .setParameter(eq("userId"), eq(2L));
-        verify(query)
                 .setParameter(eq("query"), queryCaptor.capture());
         assertEquals(tsquery, queryCaptor.getValue());
         verify(query, never())
@@ -159,8 +159,6 @@ public class RecipeSearchRepositoryImplTest {
 
         verify(entityManager)
                 .createNativeQuery(sqlCaptor.capture(), eq(Recipe.class));
-        verify(query)
-                .setParameter(eq("userId"), eq(2L));
         verify(query)
                 .setParameter(eq("ownerIds"), eq(Set.of(2L)));
         verify(query)

--- a/src/test/resources/com/brennaswitzer/cookbook/graphql/support/with_sections.json
+++ b/src/test/resources/com/brennaswitzer/cookbook/graphql/support/with_sections.json
@@ -1,0 +1,70 @@
+{
+  "type": "Recipe",
+  "name": "With Sections",
+  "directions": "First the flugel, then the booble",
+  "ingredients": [
+    {
+      "ingredientId": 87,
+      "preparation": "",
+      "raw": "Slow-Rise Pizza Crust"
+    },
+    {
+      "ingredientId": 8777749711659,
+      "preparation": "",
+      "raw": "1/2 jar of spaghetti sauce",
+      "quantity": 0.5
+    },
+    {
+      "ingredientId": 8777749736581,
+      "preparation": "sliced",
+      "raw": "3 c sliced lamb chops",
+      "quantity": 3,
+      "uomId": 8777749698019
+    },
+    {
+      "ingredientId": 8777749708459,
+      "preparation": "",
+      "raw": "onion powder"
+    }
+  ],
+  "sections": [
+    {
+      "id": 48,
+      "name": "ignored"
+    },
+    {
+      "id": 8777749736580,
+      "name": "Italian Dressing",
+      "ingredients": [
+        {
+          "ingredientId": 8777749707259,
+          "raw": "salt"
+        },
+        {
+          "ingredientId": 8777749712779,
+          "raw": "pepper"
+        },
+        {
+          "preparation": "herbs",
+          "raw": "herbs"
+        },
+        {
+          "ingredientId": 8777749712239,
+          "raw": "olive oil"
+        },
+        {
+          "ingredientId": 8777749702979,
+          "raw": "balsamic vinegar"
+        }
+      ],
+      "directions": "Combine all ingredients and shake",
+      "labels": [
+        "section",
+        "dressing"
+      ]
+    }
+  ],
+  "labels": [
+    "top-level"
+  ]
+}


### PR DESCRIPTION
Within a recipe, allow marking an ingredient ref pointing to another recipe as "a section". Refs marked this way are no longer returned within the recipe's list of ingredients, but instead as an already-dereferenced Section in GraphQL responses.

Also allow marking recipes as "section of" another recipe. The section will be deleted when the recipe is deleted, and the section will not be returned in search results. A new `LibraryQuery.sections` field can be used to search _only_ these section recipes.

Tangentially, "search via GraphQL" has become more structured with some new input types and various handlers. Not really anything different, just packaged up so sections and recipes can share a bunch of the machinery. These concepts are distinct within the GraphQL layer, even though they are undifferentiated in the database.

The client changes are at https://github.com/folded-ear/gobrennas-client/pull/287