### PR TITLE
allow an owned section to change owners if its recipe is deleted

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/graphql/support/Info2Recipe.java
+++ b/src/main/java/com/brennaswitzer/cookbook/graphql/support/Info2Recipe.java
@@ -86,7 +86,6 @@ public class Info2Recipe {
                     toRemove = List.copyOf(r.getOwnedSections());
                 }
                 toRemove.forEach(recipeService::removeOwnedSection);
-
             }
             setCoreInfo(info, r);
             if (info.hasSections()) {

--- a/src/main/java/com/brennaswitzer/cookbook/repositories/RecipeSearchRepositoryImpl.java
+++ b/src/main/java/com/brennaswitzer/cookbook/repositories/RecipeSearchRepositoryImpl.java
@@ -52,7 +52,8 @@ public class RecipeSearchRepositoryImpl implements RecipeSearchRepository {
                        FROM ingredient ing
                        """);
         boolean considerFavorites = !request.isFiltered()
-                                    && request.getType() == LibrarySearchType.TOP_LEVEL_RECIPE;
+                                    && request.getType() == LibrarySearchType.TOP_LEVEL_RECIPE
+                                    && request.getUser() != null;
         if (considerFavorites) {
             builder.append("""
                                 LEFT JOIN favorite fav


### PR DESCRIPTION
When deleting a recipe with owned sections which are referenced in other recipes, try to keep it in the same user's library, but don't require it, if only other users' recipes reference it.