### PR TITLE
add key rotation and typ/aud validation to FTOKEN

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/security/AbstractTokenAuthenticationFilter.java
+++ b/src/main/java/com/brennaswitzer/cookbook/security/AbstractTokenAuthenticationFilter.java
@@ -4,8 +4,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -16,6 +15,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Slf4j
 public abstract class AbstractTokenAuthenticationFilter extends OncePerRequestFilter {
 
     @Autowired
@@ -24,29 +24,32 @@ public abstract class AbstractTokenAuthenticationFilter extends OncePerRequestFi
     @Autowired
     private CustomUserDetailsService customUserDetailsService;
 
-    private static final Logger logger = LoggerFactory.getLogger(AbstractTokenAuthenticationFilter.class);
-
     @Override
-    protected final void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+    protected final void doFilterInternal(HttpServletRequest request,
+                                          HttpServletResponse response,
+                                          FilterChain filterChain) throws ServletException, IOException {
         if (SecurityContextHolder.getContext().getAuthentication() == null) {
-            logger.debug("consult {} for a token", this);
+            log.debug("consult {} for a token", this);
             try {
                 String jwt = getJwtFromRequest(request);
 
-                if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+                if (StringUtils.hasText(jwt)) {
                     Long userId = tokenProvider.getUserIdFromToken(jwt);
 
                     UserDetails userDetails = customUserDetailsService.loadUserById(userId);
-                    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                            userDetails,
+                            null,
+                            userDetails.getAuthorities());
                     authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 }
             } catch (Exception ex) {
-                logger.error("Could not set user authentication in security context", ex);
+                log.error("Could not set user authentication in security context", ex);
             }
         } else {
-            logger.debug("already have an authentication");
+            log.debug("already have an authentication");
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/com/brennaswitzer/cookbook/security/BfsSigningKeyResolver.java
+++ b/src/main/java/com/brennaswitzer/cookbook/security/BfsSigningKeyResolver.java
@@ -1,0 +1,79 @@
+package com.brennaswitzer.cookbook.security;
+
+import com.brennaswitzer.cookbook.config.AppProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.SigningKeyResolverAdapter;
+import io.jsonwebtoken.impl.TextCodec;
+import lombok.Getter;
+import lombok.val;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * I can resolve symmetric keys for signing/verifying JWTs. I'm a stopgap on the
+ * way to replacing jjwt with nimbus-jose-jwt, so rotation can be added now.
+ */
+@Component
+public class BfsSigningKeyResolver extends SigningKeyResolverAdapter {
+
+    public record Key(String id,
+                      byte[] bytes) {}
+
+    public static final String ANONYMOUS_KEY_ID = "?";
+
+    @Getter
+    private Key signingKey;
+    private Map<String, byte[]> keyBytesById;
+
+    @Autowired
+    public void setAppProperties(AppProperties appProperties) {
+        val auth = appProperties.getAuth();
+        val keys = new ArrayList<Key>();
+        // named secrets take priority
+        if (auth.getTokenSecrets() != null) {
+            Base64.Decoder decoder = Base64.getDecoder();
+            auth.getTokenSecrets()
+                    .stream()
+                    .map(s -> new Key(
+                            s.getId(),
+                            decoder.decode(s.getSecret())))
+                    .forEach(keys::add);
+        }
+        // support the old anonymous secret, if present
+        if (auth.getTokenSecret() != null) {
+            // this uses more lenient decoding to match jjwt
+            keys.add(new Key(
+                    ANONYMOUS_KEY_ID,
+                    TextCodec.BASE64.decode(auth.getTokenSecret())));
+        }
+        if (keys.isEmpty()) {
+            throw new IllegalStateException("At least one token secret must be provided");
+        }
+        // always sign with the first key
+        signingKey = keys.get(0);
+        // support verifying with any key
+        keyBytesById = new HashMap<>();
+        for (var k : keys) {
+            if (keyBytesById.containsKey(k.id())) {
+                throw new IllegalStateException("Multiple token secrets with id '" + k.id() + "' are present.");
+            }
+            keyBytesById.put(k.id(), k.bytes());
+        }
+    }
+
+    @Override
+    public byte[] resolveSigningKeyBytes(JwsHeader header, Claims claims) {
+        String id = header.getKeyId();
+        // if no keyId is provided, assume anonymous
+        if (id == null) id = ANONYMOUS_KEY_ID;
+        // If the id is unknown, use the signing key
+        return keyBytesById.getOrDefault(id, signingKey.bytes());
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,6 +61,9 @@ app:
     bucket-name: ${AWS_S3_BUCKET_NAME}
   auth:
     tokenSecret: ${TOKEN_SECRET}
+    # Use pairs of env vars like APP_AUTH_TOKEN_SECRETS_0_ID and
+    # APP_AUTH_TOKEN_SECRETS_0_SECRET to register token secrets. The zeroth will
+    # be used to sign, but any number can be present (for verification).
     tokenExpirationMsec: 864000000
   oauth2:
     # After successfully authenticating with the OAuth2 Provider,

--- a/src/test/java/com/brennaswitzer/cookbook/security/BfsSigningKeyResolverTest.java
+++ b/src/test/java/com/brennaswitzer/cookbook/security/BfsSigningKeyResolverTest.java
@@ -1,0 +1,123 @@
+package com.brennaswitzer.cookbook.security;
+
+import com.brennaswitzer.cookbook.config.AppProperties;
+import io.jsonwebtoken.impl.DefaultClaims;
+import io.jsonwebtoken.impl.DefaultJwsHeader;
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BfsSigningKeyResolverTest {
+
+    private BfsSigningKeyResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new BfsSigningKeyResolver();
+        val appProps = new AppProperties();
+        val auth = appProps.getAuth();
+        auth.setTokenSecret("anon");
+        auth.setTokenSecrets(List.of(
+                new AppProperties.Secret("a", "keyA"),
+                new AppProperties.Secret("z", "keyZ")));
+        resolver.setAppProperties(appProps);
+    }
+
+    @Test
+    void signingKey_firstSecret() {
+        BfsSigningKeyResolver.Key key = resolver.getSigningKey();
+
+        assertEquals("a",
+                     key.id());
+        assertArrayEquals(decode("keyA"),
+                          key.bytes());
+    }
+
+    @Test
+    void signingKey_noSecrets() {
+        resolver = new BfsSigningKeyResolver();
+        val appProps = new AppProperties();
+        val auth = appProps.getAuth();
+        auth.setTokenSecret("anon");
+        resolver.setAppProperties(appProps);
+
+        BfsSigningKeyResolver.Key key = resolver.getSigningKey();
+
+        assertEquals(BfsSigningKeyResolver.ANONYMOUS_KEY_ID,
+                     key.id());
+        assertArrayEquals(decode("anon"),
+                          key.bytes());
+    }
+
+    @Test
+    void signingKey_onlySecrets() {
+        resolver = new BfsSigningKeyResolver();
+        val appProps = new AppProperties();
+        val auth = appProps.getAuth();
+        auth.setTokenSecrets(List.of(
+                new AppProperties.Secret("a", "keyA")));
+        resolver.setAppProperties(appProps);
+
+        BfsSigningKeyResolver.Key key = resolver.getSigningKey();
+
+        assertEquals("a",
+                     key.id());
+        assertArrayEquals(decode("keyA"),
+                          key.bytes());
+    }
+
+    @Test
+    void noKeyId() {
+        assertArrayEquals(decode("anon"),
+                          resolver.resolveSigningKeyBytes(
+                                  new DefaultJwsHeader(),
+                                  new DefaultClaims()));
+    }
+
+    @Test
+    void anonymousKey() {
+        assertArrayEquals(decode("anon"),
+                          resolver.resolveSigningKeyBytes(
+                                  new DefaultJwsHeader()
+                                          .setKeyId(BfsSigningKeyResolver.ANONYMOUS_KEY_ID),
+                                  new DefaultClaims()));
+    }
+
+    @Test
+    void keyA() {
+        assertArrayEquals(decode("keyA"),
+                          resolver.resolveSigningKeyBytes(
+                                  new DefaultJwsHeader()
+                                          .setKeyId("a"),
+                                  new DefaultClaims()));
+    }
+
+    @Test
+    void keyZ() {
+        assertArrayEquals(decode("keyZ"),
+                          resolver.resolveSigningKeyBytes(
+                                  new DefaultJwsHeader()
+                                          .setKeyId("z"),
+                                  new DefaultClaims()));
+    }
+
+    @Test
+    void unknownKey() {
+        assertArrayEquals(decode("keyA"),
+                          resolver.resolveSigningKeyBytes(
+                                  new DefaultJwsHeader()
+                                          .setKeyId("unknown"),
+                                  new DefaultClaims()));
+    }
+
+    private static byte[] decode(String s) {
+        return Base64.getDecoder().decode(s);
+    }
+
+}


### PR DESCRIPTION
Support defining multiple secrets for signing `FTOKEN`, so that we can rotate without breaking sessions. In particular, need to lengthen the secrets to conform to the the JWT RFCs' [requirements](https://datatracker.ietf.org/doc/html/rfc7518#section-3.2). The older version of `jjwt` we're using doesn't enforce these reqs, but both newer versions of `jjwt` and Nimbus do.

The `BfsSigningKeyResolver` will either become a `Locator<Key>` or `KeySet`, when `jjwt` is upgraded/replaced.

Also add `typ` and `aud` claims to newly minted tokens, and verify them (if present) as part of verifying the token.

`TOKEN_SECRET` env var is still supported, but deprecated. Instead create an array of id:secret pairs, where each secret is at least 512 bites, base64-encoded:

```
APP_AUTH_TOKEN_SECRETS_0_ID=my-updated-secret
APP_AUTH_TOKEN_SECRETS_0_SECRET=Bye...==
APP_AUTH_TOKEN_SECRETS_1_ID=my-first-secret
APP_AUTH_TOKEN_SECRETS_1_SECRET=Cya...==
```
