### PR TITLE
process an empty ingredients list from the client

### DIFF
--- a/src/main/java/com/brennaswitzer/cookbook/payload/CoreRecipeInfo.java
+++ b/src/main/java/com/brennaswitzer/cookbook/payload/CoreRecipeInfo.java
@@ -24,7 +24,7 @@ public class CoreRecipeInfo implements Identified {
     }
 
     public boolean hasIngredients() {
-        return getIngredients() != null && !getIngredients().isEmpty();
+        return getIngredients() != null;
     }
 
 }


### PR DESCRIPTION
This solves both issues observed this morning:

1. the last ingredient can be removed from a recipe, and
2. extra by-reference copies of every owned section are no longer created.